### PR TITLE
Adds MacOS installation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ It lets you focus on your analysis of data, instead of plotting.
 
 ## Installation
 
+### MacOS;
+
+```
+$ brew install Python
+$ pip3 install matplotlib
+$ bundle
+$ bin/console
+> Charty
+=> Charty
+```
+
 ### With Matplotlib
 
 ```

--- a/charty.gemspec
+++ b/charty.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "matplotlib"
 end


### PR DESCRIPTION
There was no explain about MacOS installation.
I wrote to README that. And, I added "matplotlib" to charty.gemspec because it's better than write to README.