### PR TITLE
Add google charts backend

### DIFF
--- a/examples/sample_google_chart.ipynb
+++ b/examples/sample_google_chart.ipynb
@@ -4,7 +4,18 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "#<Charty::Plotter:0x00007f9ff6210d20 @plotter_adapter=#<Charty::GoogleChart:0x00007f9ff718c178>>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "require 'charty'\n",
     "\n",
@@ -15,7 +26,55 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\n",
+       "          <script type=\"text/javascript\">\n",
+       "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
+       "            google.charts.setOnLoadCallback(drawChart);\n",
+       "            function drawChart() {\n",
+       "              const data = google.visualization.arrayToDataTable(\n",
+       "                [[\"foo\", \"0\", \"1\"], [\"0\", 10, 30], [\"1\", 20, 40], [\"2\", 70, 50], [\"4\", 60, 0]]\n",
+       "              );\n",
+       "\n",
+       "              const view = new google.visualization.DataView(data);\n",
+       "\n",
+       "              const options = {\n",
+       "                title: \"this is the title\",\n",
+       "                vAxis: {\n",
+       "                  title: \"foo\"\n",
+       "                },\n",
+       "                hAxis: {\n",
+       "                  title: \"bara\"\n",
+       "                },\n",
+       "                legend: { position: \"none\" },\n",
+       "              };\n",
+       "              const chart = new google.visualization.BarChart(document.getElementById(\"barchart_values\"));\n",
+       "              chart.draw(view, options);\n",
+       "            }\n",
+       "          </script>\n",
+       "          <div id=\"barchart_values\" style=\"width: 900px; height: 300px;\"></div>\n"
+      ],
+      "text/plain": [
+       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"0\\\", \\\"1\\\"], [\\\"0\\\", 10, 30], [\\\"1\\\", 20, 40], [\\\"2\\\", 70, 50], [\\\"4\\\", 60, 0]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"this is the title\\\",\\n                vAxis: {\\n                  title: \\\"foo\\\"\\n                },\\n                hAxis: {\\n                  title: \\\"bara\\\"\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BarChart(document.getElementById(\\\"barchart_values\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"barchart_values\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "#<CZTop::Socket::PUB:0x7f9ff9af7d70 last_endpoint=\"tcp://127.0.0.1:65072\">"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "bar = charty.bar do\n",
     "  xlabel 'foo'\n",

--- a/examples/sample_google_chart.ipynb
+++ b/examples/sample_google_chart.ipynb
@@ -8,7 +8,7 @@
     {
      "data": {
       "text/plain": [
-       "#<Charty::Plotter:0x00007f9ff6210d20 @plotter_adapter=#<Charty::GoogleChart:0x00007f9ff718c178>>"
+       "#<Charty::Plotter:0x00007f83d19dd968 @plotter_adapter=#<Charty::GoogleChart:0x00007f83d19797d8>>"
       ]
      },
      "execution_count": 1,
@@ -30,35 +30,10 @@
     {
      "data": {
       "text/html": [
-       "          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\n",
-       "          <script type=\"text/javascript\">\n",
-       "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
-       "            google.charts.setOnLoadCallback(drawChart);\n",
-       "            function drawChart() {\n",
-       "              const data = google.visualization.arrayToDataTable(\n",
-       "                [[\"foo\", \"0\", \"1\"], [\"0\", 10, 30], [\"1\", 20, 40], [\"2\", 70, 50], [\"4\", 60, 0]]\n",
-       "              );\n",
-       "\n",
-       "              const view = new google.visualization.DataView(data);\n",
-       "\n",
-       "              const options = {\n",
-       "                title: \"this is the title\",\n",
-       "                vAxis: {\n",
-       "                  title: \"foo\"\n",
-       "                },\n",
-       "                hAxis: {\n",
-       "                  title: \"bara\"\n",
-       "                },\n",
-       "                legend: { position: \"none\" },\n",
-       "              };\n",
-       "              const chart = new google.visualization.BarChart(document.getElementById(\"barchart_values\"));\n",
-       "              chart.draw(view, options);\n",
-       "            }\n",
-       "          </script>\n",
-       "          <div id=\"barchart_values\" style=\"width: 900px; height: 300px;\"></div>\n"
+       "2"
       ],
       "text/plain": [
-       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"0\\\", \\\"1\\\"], [\\\"0\\\", 10, 30], [\\\"1\\\", 20, 40], [\\\"2\\\", 70, 50], [\\\"4\\\", 60, 0]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"this is the title\\\",\\n                vAxis: {\\n                  title: \\\"foo\\\"\\n                },\\n                hAxis: {\\n                  title: \\\"bara\\\"\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BarChart(document.getElementById(\\\"barchart_values\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"barchart_values\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+       "2"
       ]
      },
      "metadata": {},
@@ -67,7 +42,7 @@
     {
      "data": {
       "text/plain": [
-       "#<CZTop::Socket::PUB:0x7f9ff9af7d70 last_endpoint=\"tcp://127.0.0.1:65072\">"
+       "#<CZTop::Socket::PUB:0x7f83d5543790 last_endpoint=\"tcp://127.0.0.1:65072\">"
       ]
      },
      "execution_count": 2,
@@ -88,10 +63,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "3"
+      ],
+      "text/plain": [
+       "3"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "#<CZTop::Socket::PUB:0x7f83d5543790 last_endpoint=\"tcp://127.0.0.1:65072\">"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "scatter = charty.scatter do\n",
+    "  xlabel 'foo'\n",
+    "  ylabel 'bara'\n",
+    "  series [0, 1, 4,  2], [10, 20, 60, 70]\n",
+    "  series [0, 1, 2], [30, 40, 50]\n",
+    "  title 'this is the title'\n",
+    "end\n",
+    "IRuby.display(IRuby.html(scatter.render))"
+   ]
   },
   {
    "cell_type": "code",

--- a/examples/sample_google_chart.ipynb
+++ b/examples/sample_google_chart.ipynb
@@ -8,7 +8,7 @@
     {
      "data": {
       "text/plain": [
-       "#<Charty::Plotter:0x00007f83d19dd968 @plotter_adapter=#<Charty::GoogleChart:0x00007f83d19797d8>>"
+       "#<Charty::Plotter:0x00007fc44239a540 @plotter_adapter=#<Charty::GoogleChart:0x00007fc4440b3780>>"
       ]
      },
      "execution_count": 1,
@@ -18,7 +18,6 @@
    ],
    "source": [
     "require 'charty'\n",
-    "\n",
     "charty = Charty::Plotter.new(:google_chart)"
    ]
   },
@@ -30,10 +29,43 @@
     {
      "data": {
       "text/html": [
-       "2"
+       "          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\n",
+       "          <script type=\"text/javascript\">\n",
+       "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
+       "            google.charts.setOnLoadCallback(drawChart);\n",
+       "            function drawChart() {\n",
+       "              const data = google.visualization.arrayToDataTable(\n",
+       "                [[\"foo\", \"\", \"\"], [\"0\", 10, 30], [\"1\", 20, 40], [\"2\", 70, 50], [\"4\", 60, \"null\"]]\n",
+       "              );\n",
+       "\n",
+       "              const view = new google.visualization.DataView(data);\n",
+       "\n",
+       "              const options = {\n",
+       "                title: \"this is the title\",\n",
+       "                vAxis: {\n",
+       "                  title: \"bara\",\n",
+       "                  viewWindow: {\n",
+       "                    max: null,\n",
+       "                    min: null,\n",
+       "                  },\n",
+       "                },\n",
+       "                hAxis: {\n",
+       "                  title: \"foo\",\n",
+       "                  viewWindow: {\n",
+       "                    max: null,\n",
+       "                    min: null,\n",
+       "                  }\n",
+       "                },\n",
+       "                legend: { position: \"none\" },\n",
+       "              };\n",
+       "              const chart = new google.visualization.BarChart(document.getElementById(\"BarChart-1\"));\n",
+       "              chart.draw(view, options);\n",
+       "            }\n",
+       "          </script>\n",
+       "          <div id=\"BarChart-1\" style=\"width: 900px; height: 300px;\"></div>\n"
       ],
       "text/plain": [
-       "2"
+       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"\\\", \\\"\\\"], [\\\"0\\\", 10, 30], [\\\"1\\\", 20, 40], [\\\"2\\\", 70, 50], [\\\"4\\\", 60, \\\"null\\\"]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"this is the title\\\",\\n                vAxis: {\\n                  title: \\\"bara\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BarChart(document.getElementById(\\\"BarChart-1\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"BarChart-1\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
       ]
      },
      "metadata": {},
@@ -42,7 +74,7 @@
     {
      "data": {
       "text/plain": [
-       "#<CZTop::Socket::PUB:0x7f83d5543790 last_endpoint=\"tcp://127.0.0.1:65072\">"
+       "#<CZTop::Socket::PUB:0x7fc4430de3c0 last_endpoint=\"tcp://127.0.0.1:49318\">"
       ]
      },
      "execution_count": 2,
@@ -69,10 +101,43 @@
     {
      "data": {
       "text/html": [
-       "3"
+       "          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\n",
+       "          <script type=\"text/javascript\">\n",
+       "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
+       "            google.charts.setOnLoadCallback(drawChart);\n",
+       "            function drawChart() {\n",
+       "              const data = google.visualization.arrayToDataTable(\n",
+       "                [[\"\", \"sample1\", \"sample2\", \"\"], [\"0\", 0.0, 0.0, 0], [\"1\", 0.1, 0.2, -0.1], [\"2\", 0.2, 0.4, -0.5], [\"3\", 0.30000000000000004, 0.6000000000000001, -0.5], [\"4\", 0.4, 0.8, 0.1], [\"5\", 0.5, 1.0, \"null\"], [\"6\", 0.6000000000000001, \"null\", \"null\"], [\"7\", 0.7000000000000001, \"null\", \"null\"], [\"8\", 0.8, \"null\", \"null\"], [\"9\", 0.9, \"null\", \"null\"], [\"10\", 1.0, \"null\", \"null\"]]\n",
+       "              );\n",
+       "\n",
+       "              const view = new google.visualization.DataView(data);\n",
+       "\n",
+       "              const options = {\n",
+       "                title: \"scatter sample\",\n",
+       "                vAxis: {\n",
+       "                  title: \"y label\",\n",
+       "                  viewWindow: {\n",
+       "                    max: null,\n",
+       "                    min: null,\n",
+       "                  },\n",
+       "                },\n",
+       "                hAxis: {\n",
+       "                  title: \"\",\n",
+       "                  viewWindow: {\n",
+       "                    max: null,\n",
+       "                    min: null,\n",
+       "                  }\n",
+       "                },\n",
+       "                legend: { position: \"none\" },\n",
+       "              };\n",
+       "              const chart = new google.visualization.ScatterChart(document.getElementById(\"ScatterChart-2\"));\n",
+       "              chart.draw(view, options);\n",
+       "            }\n",
+       "          </script>\n",
+       "          <div id=\"ScatterChart-2\" style=\"width: 900px; height: 300px;\"></div>\n"
       ],
       "text/plain": [
-       "3"
+       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"\\\", \\\"sample1\\\", \\\"sample2\\\", \\\"\\\"], [\\\"0\\\", 0.0, 0.0, 0], [\\\"1\\\", 0.1, 0.2, -0.1], [\\\"2\\\", 0.2, 0.4, -0.5], [\\\"3\\\", 0.30000000000000004, 0.6000000000000001, -0.5], [\\\"4\\\", 0.4, 0.8, 0.1], [\\\"5\\\", 0.5, 1.0, \\\"null\\\"], [\\\"6\\\", 0.6000000000000001, \\\"null\\\", \\\"null\\\"], [\\\"7\\\", 0.7000000000000001, \\\"null\\\", \\\"null\\\"], [\\\"8\\\", 0.8, \\\"null\\\", \\\"null\\\"], [\\\"9\\\", 0.9, \\\"null\\\", \\\"null\\\"], [\\\"10\\\", 1.0, \\\"null\\\", \\\"null\\\"]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"scatter sample\\\",\\n                vAxis: {\\n                  title: \\\"y label\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.ScatterChart(document.getElementById(\\\"ScatterChart-2\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"ScatterChart-2\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
       ]
      },
      "metadata": {},
@@ -81,7 +146,7 @@
     {
      "data": {
       "text/plain": [
-       "#<CZTop::Socket::PUB:0x7f83d5543790 last_endpoint=\"tcp://127.0.0.1:65072\">"
+       "#<CZTop::Socket::PUB:0x7fc4430de3c0 last_endpoint=\"tcp://127.0.0.1:49318\">"
       ]
      },
      "execution_count": 3,
@@ -91,13 +156,87 @@
    ],
    "source": [
     "scatter = charty.scatter do\n",
-    "  xlabel 'foo'\n",
-    "  ylabel 'bara'\n",
-    "  series [0, 1, 4,  2], [10, 20, 60, 70]\n",
-    "  series [0, 1, 2], [30, 40, 50]\n",
-    "  title 'this is the title'\n",
+    "  series 0..10, (0..1).step(0.1), label: 'sample1'\n",
+    "  series 0..5, (0..1).step(0.2), label: 'sample2'\n",
+    "  series [0, 1, 2, 3, 4], [0, -0.1, -0.5, -0.5, 0.1]\n",
+    "  ylabel 'y label'\n",
+    "  title 'scatter sample'\n",
     "end\n",
     "IRuby.display(IRuby.html(scatter.render))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\n",
+       "          <script type=\"text/javascript\">\n",
+       "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
+       "            google.charts.setOnLoadCallback(drawChart);\n",
+       "            function drawChart() {\n",
+       "              const data = google.visualization.arrayToDataTable(\n",
+       "                [[\"ID\", \"X\", \"Y\", \"GROUP\", \"SIZE\"], [\"\", 0, 0.0, \"sample1\", 10], [\"\", 1, 0.1, \"sample1\", 100], [\"\", 2, 0.2, \"sample1\", 1000], [\"\", 3, 0.30000000000000004, \"sample1\", 20], [\"\", 4, 0.4, \"sample1\", 200], [\"\", 5, 0.5, \"sample1\", 2000], [\"\", 6, 0.6000000000000001, \"sample1\", 5], [\"\", 7, 0.7000000000000001, \"sample1\", 50], [\"\", 8, 0.8, \"sample1\", 500], [\"\", 9, 0.9, \"sample1\", 4], [\"\", 10, 1.0, \"sample1\", 40], [\"\", 0, 0.0, \"sample2\", 1], [\"\", 1, 0.2, \"sample2\", 10], [\"\", 2, 0.4, \"sample2\", 100], [\"\", 3, 0.6000000000000001, \"sample2\", 1000], [\"\", 4, 0.8, \"sample2\", 500], [\"\", 5, 1.0, \"sample2\", 100], [\"\", 0, 0, 2, 40], [\"\", 1, -0.1, 2, 30], [\"\", 2, -0.5, 2, 200], [\"\", 3, -0.5, 2, 10], [\"\", 4, 0.1, 2, 5]]\n",
+       "              );\n",
+       "\n",
+       "              const view = new google.visualization.DataView(data);\n",
+       "\n",
+       "              const options = {\n",
+       "                title: \"bubble sample\",\n",
+       "                vAxis: {\n",
+       "                  title: \"y label\",\n",
+       "                  viewWindow: {\n",
+       "                    max: 1,\n",
+       "                    min: -1,\n",
+       "                  },\n",
+       "                },\n",
+       "                hAxis: {\n",
+       "                  title: \"x label\",\n",
+       "                  viewWindow: {\n",
+       "                    max: 10,\n",
+       "                    min: 0,\n",
+       "                  }\n",
+       "                },\n",
+       "                legend: { position: \"none\" },\n",
+       "              };\n",
+       "              const chart = new google.visualization.BubbleChart(document.getElementById(\"BubbleChart-3\"));\n",
+       "              chart.draw(view, options);\n",
+       "            }\n",
+       "          </script>\n",
+       "          <div id=\"BubbleChart-3\" style=\"width: 900px; height: 300px;\"></div>\n"
+      ],
+      "text/plain": [
+       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"ID\\\", \\\"X\\\", \\\"Y\\\", \\\"GROUP\\\", \\\"SIZE\\\"], [\\\"\\\", 0, 0.0, \\\"sample1\\\", 10], [\\\"\\\", 1, 0.1, \\\"sample1\\\", 100], [\\\"\\\", 2, 0.2, \\\"sample1\\\", 1000], [\\\"\\\", 3, 0.30000000000000004, \\\"sample1\\\", 20], [\\\"\\\", 4, 0.4, \\\"sample1\\\", 200], [\\\"\\\", 5, 0.5, \\\"sample1\\\", 2000], [\\\"\\\", 6, 0.6000000000000001, \\\"sample1\\\", 5], [\\\"\\\", 7, 0.7000000000000001, \\\"sample1\\\", 50], [\\\"\\\", 8, 0.8, \\\"sample1\\\", 500], [\\\"\\\", 9, 0.9, \\\"sample1\\\", 4], [\\\"\\\", 10, 1.0, \\\"sample1\\\", 40], [\\\"\\\", 0, 0.0, \\\"sample2\\\", 1], [\\\"\\\", 1, 0.2, \\\"sample2\\\", 10], [\\\"\\\", 2, 0.4, \\\"sample2\\\", 100], [\\\"\\\", 3, 0.6000000000000001, \\\"sample2\\\", 1000], [\\\"\\\", 4, 0.8, \\\"sample2\\\", 500], [\\\"\\\", 5, 1.0, \\\"sample2\\\", 100], [\\\"\\\", 0, 0, 2, 40], [\\\"\\\", 1, -0.1, 2, 30], [\\\"\\\", 2, -0.5, 2, 200], [\\\"\\\", 3, -0.5, 2, 10], [\\\"\\\", 4, 0.1, 2, 5]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"bubble sample\\\",\\n                vAxis: {\\n                  title: \\\"y label\\\",\\n                  viewWindow: {\\n                    max: 1,\\n                    min: -1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"x label\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BubbleChart(document.getElementById(\\\"BubbleChart-3\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"BubbleChart-3\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "#<CZTop::Socket::PUB:0x7fc4430de3c0 last_endpoint=\"tcp://127.0.0.1:49318\">"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bubble = charty.bubble do\n",
+    "  series 0..10, (0..1).step(0.1), [10, 100, 1000, 20, 200, 2000, 5, 50, 500, 4, 40], label: 'sample1'\n",
+    "  series 0..5, (0..1).step(0.2), [1, 10, 100, 1000, 500, 100], label: 'sample2'\n",
+    "  series [0, 1, 2, 3, 4], [0, -0.1, -0.5, -0.5, 0.1], [40, 30, 200, 10, 5]\n",
+    "  range x: 0..10, y: -1..1\n",
+    "  xlabel 'x label'\n",
+    "  ylabel 'y label'\n",
+    "  title 'bubble sample'\n",
+    "end\n",
+    "IRuby.display(IRuby.html(bubble.render))"
    ]
   },
   {

--- a/examples/sample_google_chart.ipynb
+++ b/examples/sample_google_chart.ipynb
@@ -4,18 +4,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "#<Charty::Plotter:0x00007fa7812c3be0 @frontend=#<Charty::GoogleChart:0x00007fa7812bf798>>"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "require 'charty'\n",
     "\n",
@@ -24,58 +13,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\n",
-       "          <script type=\"text/javascript\">\n",
-       "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
-       "            google.charts.setOnLoadCallback(drawChart);\n",
-       "            function drawChart() {\n",
-       "              var data = google.visualization.arrayToDataTable(\n",
-       "                [[\"foo\", \"0\", \"1\"], [\"0\", 10, 30], [\"1\", 20, 40], [\"2\", 70, 50], [\"4\", 60, 0]]\n",
-       "              );\n",
-       "\n",
-       "              var view = new google.visualization.DataView(data);\n",
-       "\n",
-       "              var options = {\n",
-       "                title: \"this is the title\",\n",
-       "                bar: {groupWidth: \"95%\"},\n",
-       "                vAxis: {\n",
-       "                  title: \"foo\"\n",
-       "                },\n",
-       "                hAxis: {\n",
-       "                  title: \"bara\"\n",
-       "                },\n",
-       "                legend: { position: \"none\" },\n",
-       "              };\n",
-       "              var chart = new google.visualization.BarChart(document.getElementById(\"barchart_values\"));\n",
-       "              chart.draw(view, options);\n",
-       "            }\n",
-       "          </script>\n",
-       "          <div id=\"barchart_values\" style=\"width: 900px; height: 300px;\"></div>\n"
-      ],
-      "text/plain": [
-       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              var data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"0\\\", \\\"1\\\"], [\\\"0\\\", 10, 30], [\\\"1\\\", 20, 40], [\\\"2\\\", 70, 50], [\\\"4\\\", 60, 0]]\\n              );\\n\\n              var view = new google.visualization.DataView(data);\\n\\n              var options = {\\n                title: \\\"this is the title\\\",\\n                bar: {groupWidth: \\\"95%\\\"},\\n                vAxis: {\\n                  title: \\\"foo\\\"\\n                },\\n                hAxis: {\\n                  title: \\\"bara\\\"\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              var chart = new google.visualization.BarChart(document.getElementById(\\\"barchart_values\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"barchart_values\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "#<CZTop::Socket::PUB:0x7fa784c2fe00 last_endpoint=\"tcp://127.0.0.1:59332\">"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bar = charty.bar do\n",
     "  xlabel 'foo'\n",
@@ -89,20 +29,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              var data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"0\\\", \\\"1\\\"], [\\\"0\\\", 10, 30], [\\\"1\\\", 20, 40], [\\\"2\\\", 70, 50], [\\\"4\\\", 60, 0]]\\n              );\\n\\n              var view = new google.visualization.DataView(data);\\n\\n              var options = {\\n                title: \\\"this is the title\\\",\\n                bar: {groupWidth: \\\"95%\\\"},\\n                vAxis: {\\n                  title: \\\"foo\\\"\\n                },\\n                hAxis: {\\n                  title: \\\"bara\\\"\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              var chart = new google.visualization.BarChart(document.getElementById(\\\"barchart_values\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"barchart_values\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": []
   },
   {

--- a/examples/sample_google_chart.ipynb
+++ b/examples/sample_google_chart.ipynb
@@ -1,0 +1,131 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "#<Charty::Plotter:0x00007fa7812c3be0 @frontend=#<Charty::GoogleChart:0x00007fa7812bf798>>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "require 'charty'\n",
+    "\n",
+    "charty = Charty::Plotter.new(:google_chart)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\n",
+       "          <script type=\"text/javascript\">\n",
+       "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
+       "            google.charts.setOnLoadCallback(drawChart);\n",
+       "            function drawChart() {\n",
+       "              var data = google.visualization.arrayToDataTable(\n",
+       "                [[\"foo\", \"0\", \"1\"], [\"0\", 10, 30], [\"1\", 20, 40], [\"2\", 70, 50], [\"4\", 60, 0]]\n",
+       "              );\n",
+       "\n",
+       "              var view = new google.visualization.DataView(data);\n",
+       "\n",
+       "              var options = {\n",
+       "                title: \"this is the title\",\n",
+       "                bar: {groupWidth: \"95%\"},\n",
+       "                vAxis: {\n",
+       "                  title: \"foo\"\n",
+       "                },\n",
+       "                hAxis: {\n",
+       "                  title: \"bara\"\n",
+       "                },\n",
+       "                legend: { position: \"none\" },\n",
+       "              };\n",
+       "              var chart = new google.visualization.BarChart(document.getElementById(\"barchart_values\"));\n",
+       "              chart.draw(view, options);\n",
+       "            }\n",
+       "          </script>\n",
+       "          <div id=\"barchart_values\" style=\"width: 900px; height: 300px;\"></div>\n"
+      ],
+      "text/plain": [
+       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              var data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"0\\\", \\\"1\\\"], [\\\"0\\\", 10, 30], [\\\"1\\\", 20, 40], [\\\"2\\\", 70, 50], [\\\"4\\\", 60, 0]]\\n              );\\n\\n              var view = new google.visualization.DataView(data);\\n\\n              var options = {\\n                title: \\\"this is the title\\\",\\n                bar: {groupWidth: \\\"95%\\\"},\\n                vAxis: {\\n                  title: \\\"foo\\\"\\n                },\\n                hAxis: {\\n                  title: \\\"bara\\\"\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              var chart = new google.visualization.BarChart(document.getElementById(\\\"barchart_values\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"barchart_values\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "#<CZTop::Socket::PUB:0x7fa784c2fe00 last_endpoint=\"tcp://127.0.0.1:59332\">"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "bar = charty.bar do\n",
+    "  xlabel 'foo'\n",
+    "  ylabel 'bara'\n",
+    "  series [0, 1, 4,  2], [10, 20, 60, 70]\n",
+    "  series [0, 1, 2], [30, 40, 50]\n",
+    "  title 'this is the title'\n",
+    "end\n",
+    "IRuby.display(IRuby.html(bar.render))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              var data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"0\\\", \\\"1\\\"], [\\\"0\\\", 10, 30], [\\\"1\\\", 20, 40], [\\\"2\\\", 70, 50], [\\\"4\\\", 60, 0]]\\n              );\\n\\n              var view = new google.visualization.DataView(data);\\n\\n              var options = {\\n                title: \\\"this is the title\\\",\\n                bar: {groupWidth: \\\"95%\\\"},\\n                vAxis: {\\n                  title: \\\"foo\\\"\\n                },\\n                hAxis: {\\n                  title: \\\"bara\\\"\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              var chart = new google.visualization.BarChart(document.getElementById(\\\"barchart_values\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"barchart_values\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Ruby 2.5.5",
+   "language": "ruby",
+   "name": "ruby"
+  },
+  "language_info": {
+   "file_extension": ".rb",
+   "mimetype": "application/x-ruby",
+   "name": "ruby",
+   "version": "2.5.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/lib/charty/google_chart.rb
+++ b/lib/charty/google_chart.rb
@@ -1,5 +1,7 @@
 module Charty
-  class GoogleChart
+  class GoogleChart < PlotterAdapter
+    Name = "google_chart"
+
     def initilize
     end
 

--- a/lib/charty/google_chart.rb
+++ b/lib/charty/google_chart.rb
@@ -1,0 +1,101 @@
+module Charty
+  class GoogleChart
+    def initilize
+    end
+
+    def label(x, y)
+    end
+
+    def series=(series)
+      @series = series
+    end
+
+    def render(context, filename)
+      plot(nil, context)
+    end
+
+    def plot(plot, context)
+      case context.method
+      when :bar
+        generate_bar_chart_js(context)
+      else
+        raise NotImplementedError
+      end
+    end
+
+    private
+
+      def google_chart_load_tag
+        "<script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>"
+      end
+
+      def generate_bar_chart_js(context)
+        headers = [].tap do |header|
+          header << context.xlabel
+          context.series.each_with_index do |_series_data, index|
+            header << index
+          end
+        end
+
+        x_labels = [].tap do |label|
+          context.series.each do |series|
+            series.xs.each do |xs_data|
+              label << xs_data unless label.any? { |label| label == xs_data }
+            end
+          end
+        end
+
+        data_hash = {}.tap do |hash|
+          context.series.each_with_index do |series_data, series_index|
+            x_labels.sort.each do |x_label|
+              unless hash[x_label]
+                hash[x_label] = []
+              end
+
+              if data_index = series_data.xs.index(x_label)
+                hash[x_label] << series_data.ys[data_index]
+              else
+                hash[x_label] << 0
+              end
+            end
+          end
+        end
+
+        formatted_array = [headers.map(&:to_s)].tap do |data_array|
+          data_hash.each do |k, v|
+            data_array << [k.to_s, v].flatten
+          end
+        end
+
+        js = <<-JS
+          #{google_chart_load_tag}
+          <script type="text/javascript">
+            google.charts.load("current", {packages:["corechart"]});
+            google.charts.setOnLoadCallback(drawChart);
+            function drawChart() {
+              var data = google.visualization.arrayToDataTable(
+                #{formatted_array}
+              );
+
+              var view = new google.visualization.DataView(data);
+
+              var options = {
+                title: "#{context.title}",
+                bar: {groupWidth: "95%"},
+                vAxis: {
+                  title: "#{context.xlabel}"
+                },
+                hAxis: {
+                  title: "#{context.ylabel}"
+                },
+                legend: { position: "none" },
+              };
+              var chart = new google.visualization.BarChart(document.getElementById("barchart_values"));
+              chart.draw(view, options);
+            }
+          </script>
+          <div id="barchart_values" style="width: 900px; height: 300px;"></div>
+        JS
+      end
+  end
+end

--- a/lib/charty/plotter_adapter.rb
+++ b/lib/charty/plotter_adapter.rb
@@ -8,6 +8,7 @@ module Charty
     end
 
     def self.create(adapter_name)
+      require "charty/#{adapter_name}"
       adapter = @adapters.find {|adapter| adapter::Name.to_s == adapter_name.to_s }
       raise AdapterNotLoadedError.new("Adapter for '#{adapter_name}' is not found.") unless adapter
       adapter.new


### PR DESCRIPTION
I would like to add Google Charts support as the backend rendering engine in Charty.

I'm in the middle of implementing a bar graph feature with google charts, and want to know if I'm going in the right direction. I especially want to know if there is any thoughts in how the `#render` and `#plot` methods are supposed to behave with javascript type backend.