### PR TITLE
Automatically Require backend class before find adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,8 @@ language: ruby
 cache: bundler
 rvm:
   - 2.6.3
-apt:
-  packages:
-    - libimagemagickcore-dev
-before_script:
-  - PYENV_VERSION=3.7 pip3 install --user matplotlib
 env:
-  - PYENV_VERSION=3.7 PYTHON=python
+  - PYENV_VERSION=3.6 PYTHON=python
+before_install:
+  - gem i bundler
+  - PYENV_VERSION=3.6 pip3 install --user matplotlib

--- a/charty.gemspec
+++ b/charty.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
+  spec.add_development_dependency "matplotlib"
+  spec.add_development_dependency "gruff"
 end

--- a/test/plotter_test.rb
+++ b/test/plotter_test.rb
@@ -1,37 +1,13 @@
 require_relative './test_helper'
 
 class PlotterTest < Test::Unit::TestCase
-  def setup
-    load File.expand_path('../lib/charty/matplot.rb', __dir__)
-  end
-
-  def teardown
-    Charty.send(:remove_const, :Matplot)
-    Charty::PlotterAdapter.send(:instance_variable_set, :@adapters, [])
-  end
-
   def test_plotter_use_a_plotter_adapter
     plotter = Charty::Plotter.new :matplot
     adapter = plotter.send(:instance_variable_get, :@plotter_adapter)
     assert_instance_of(Charty::Matplot, adapter)
   end
 
-  def test_error_if_plotter_adapter_is_not_loaded
-    assert_raise_kind_of(Charty::AdapterNotLoadedError) do
-      Charty::Plotter.new(:gruff)
-    end
-  end
-
   sub_test_case("gruff adapter") do
-    def setup
-      load File.expand_path('../lib/charty/gruff.rb', __dir__)
-    end
-
-    def teardown
-      Charty.send(:remove_const, :Gruff)
-      Charty::PlotterAdapter.send(:instance_variable_set, :@adapters, [])
-    end
-
     def test_plotter_use_another_plotter_adapter
       plotter = Charty::Plotter.new :gruff
       adapter = plotter.send(:instance_variable_get, :@plotter_adapter)


### PR DESCRIPTION
If We want to execute `Charty::Plotter.new(:matplot)`.
Now, We need to execute `require charty/matplot` before that.

I think it is more convenient to automatically require the required backend class.