### PR TITLE
Remove Charty.new which is syntactic sugar for Charty::Plotter.new

### DIFF
--- a/lib/charty.rb
+++ b/lib/charty.rb
@@ -5,9 +5,3 @@ require_relative "charty/plotter_adapter"
 require_relative "charty/layout"
 require_relative "charty/linspace"
 require_relative "charty/table"
-
-module Charty
-  def self.new(*args)
-    Charty::Plotter.new(*args)
-  end
-end


### PR DESCRIPTION
It is strange that Charty.new returns an instance of Charty::Plotter