### PR TITLE
Add bokeh backend

### DIFF
--- a/charty.gemspec
+++ b/charty.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency "matplotlib"
+  spec.add_development_dependency "bokeh"
 end

--- a/charty.gemspec
+++ b/charty.gemspec
@@ -30,5 +30,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency "matplotlib"
-  spec.add_development_dependency "bokeh"
 end

--- a/lib/charty/backends/bokeh.rb
+++ b/lib/charty/backends/bokeh.rb
@@ -1,11 +1,11 @@
-require 'bokeh'
+require 'pycall'
 
 module Charty
   class Bokeh < PlotterAdapter
     Name = "bokeh"
 
     def initialize
-      @plot = ::Bokeh::Plotting
+      @plot = PyCall.import_module('bokeh.plotting')
     end
 
     def series=(series)
@@ -15,12 +15,12 @@ module Charty
     def render(context, filename)
       plot = plot(context)
       save(plot, context, filename)
-      ::Bokeh::IO::show(plot)
+      PyCall.import_module('bokeh.io').show(plot)
     end
 
     def save(plot, context, filename)
       if filename
-        ::Bokeh::IO::save(plot, filename)
+        PyCall.import_module('bokeh.io').save(plot, filename)
       end
     end
 

--- a/lib/charty/backends/bokeh.rb
+++ b/lib/charty/backends/bokeh.rb
@@ -28,6 +28,8 @@ module Charty
       #TODO To implement boxplot, bublle, error_bar, hist.
       
       plot = @plot.figure(title: context&.title)
+      plot.xaxis[0].axis_label = context&.xlabel
+      plot.yaxis[0].axis_label = context&.ylabel
       case context.method
         when :bar
           context.series.each do |data|

--- a/lib/charty/backends/bokeh.rb
+++ b/lib/charty/backends/bokeh.rb
@@ -13,14 +13,57 @@ module Charty
     end
 
     def render(context, filename)
+      plot = plot(context)
+      save(plot, context, filename)
+      ::Bokeh::IO::show(plot)
+    end
+
+    def save(plot, context, filename)
+      if filename
+        ::Bokeh::IO::save(plot, filename)
+      end
+    end
+
+    def plot(context)
+      #TODO To implement boxplot, bublle, error_bar, hist.
+      
       plot = @plot.figure(title: context&.title)
       case context.method
+        when :bar
+          context.series.each do |data|
+            plot.vbar(data.xs.to_a, nil, data.ys.to_a)
+          end
+
+        when :barh
+          context.series.each do |data|
+            context.series.each do |data|
+              plot.hbar(data.xs.to_a, nil, data.ys.to_a)
+            end
+          end
+
+        when :boxplot
+          raise NotImplementedError
+
+        when :bubble
+          raise NotImplementedError
+
         when :curve
           context.series.each do |data|
             plot.line(data.xs.to_a, data.ys.to_a)
           end
+
+        when :scatter
+          context.series.each do |data|
+            plot.scatter(data.xs.to_a, data.ys.to_a)
+          end
+
+        when :error_bar
+          raise NotImplementedError
+
+        when :hist
+          raise NotImplementedError
       end
-      ::Bokeh::IO::show(plot)
+      plot
     end
   end
 end

--- a/lib/charty/backends/bokeh.rb
+++ b/lib/charty/backends/bokeh.rb
@@ -1,0 +1,26 @@
+require 'bokeh'
+
+module Charty
+  class Bokeh < PlotterAdapter
+    Name = "bokeh"
+
+    def initialize
+      @plot = ::Bokeh::Plotting
+    end
+
+    def series=(series)
+      @series = series
+    end
+
+    def render(context, filename)
+      plot = @plot.figure(title: context&.title)
+      case context.method
+        when :curve
+          context.series.each do |data|
+            plot.line(data.xs.to_a, data.ys.to_a)
+          end
+      end
+      ::Bokeh::IO::show(plot)
+    end
+  end
+end

--- a/lib/charty/backends/bokeh.rb
+++ b/lib/charty/backends/bokeh.rb
@@ -26,21 +26,24 @@ module Charty
 
     def plot(context)
       #TODO To implement boxplot, bublle, error_bar, hist.
-      
+
       plot = @plot.figure(title: context&.title)
       plot.xaxis[0].axis_label = context&.xlabel
       plot.yaxis[0].axis_label = context&.ylabel
+
       case context.method
         when :bar
           context.series.each do |data|
-            plot.vbar(data.xs.to_a, nil, data.ys.to_a)
+            diffs = data.xs.to_a.each_cons(2).map {|n, m| (n - m).abs }
+            width = diffs.min * 0.8
+            plot.vbar(data.xs.to_a, width, data.ys.to_a)
           end
 
         when :barh
           context.series.each do |data|
-            context.series.each do |data|
-              plot.hbar(data.xs.to_a, nil, data.ys.to_a)
-            end
+            diffs = data.xs.to_a.each_cons(2).map {|n, m| (n - m).abs }
+            height = diffs.min * 0.8
+            plot.hbar(data.xs.to_a, height, data.ys.to_a)
           end
 
         when :boxplot
@@ -64,7 +67,7 @@ module Charty
 
         when :hist
           raise NotImplementedError
-      end
+        end
       plot
     end
   end


### PR DESCRIPTION
# Summary

This change will make the charty possible to use the bokeh.  

Following graphs are supported.

* `bar`
* `barh`
* `curve`
* `scatter`

Following graphs are not supported.

* `boxplot`
* `bubble`
* `error_bar`
* `hist`

# Examples

These codes are common except the called method on the `plotter`.

## curve

```ruby
require 'charty'

charty = Charty::Plotter.new(:bokeh)

figure = charty.curve do
  series (0..10).to_a, Array.new(10) { Random.rand(10) }
  xlabel 'foo'
  ylabel 'bar'
end

figure.render("sample.html")
```

![image](https://user-images.githubusercontent.com/39588288/60114446-cc590300-97ae-11e9-8bed-ed4deef04348.png)

## vertical bar

![image](https://user-images.githubusercontent.com/39588288/60115675-6621af80-97b1-11e9-9bd2-3fef17b63113.png)

## horizontal bar

![image](https://user-images.githubusercontent.com/39588288/60116283-b3525100-97b2-11e9-95d1-b0259071cbb0.png)

## scatter

![image](https://user-images.githubusercontent.com/39588288/60117978-40e37000-97b6-11e9-910d-f8dd45d12617.png)
