### PR TITLE
Add plotly backend

### DIFF
--- a/lib/charty/backends/plotly.rb
+++ b/lib/charty/backends/plotly.rb
@@ -1,5 +1,4 @@
 require 'json'
-require 'securerandom'
 
 module Charty
   class Plotly < PlotterAdapter

--- a/lib/charty/backends/plotly.rb
+++ b/lib/charty/backends/plotly.rb
@@ -1,0 +1,82 @@
+require 'json'
+require 'securerandom'
+
+module Charty
+  class Plotly < PlotterAdapter
+    Name = "plotly"
+    attr_reader :context
+
+    def initilize
+    end
+
+    def label(x, y)
+    end
+
+    def series=(series)
+      @series = series
+    end
+
+    def render(context, filename)
+      plot(nil, context)
+    end
+
+    def plot(plot, context)
+      context = context
+
+      case context.method
+      when :bar
+        render_graph(context, :bar)
+      when :curve
+        render_graph(context, :scatter)
+      when :scatter
+        render_graph(context, nil, options: {data: {mode: "markers"}})
+      else
+        raise NotImplementedError
+      end
+    end
+
+    private
+
+    def div_id
+      "charty-plotly-#{SecureRandom.uuid}"
+    end
+
+    def div_style
+      "width: 100%;height: 100%;"
+    end
+
+    def render_graph(context, type, options: {})
+      data = context.series.map do |series|
+        {
+          type: type,
+          x: series.xs.to_a,
+          y: series.ys.to_a,
+          name: series.label
+        }.merge(options[:data] || {})
+      end
+      layout = {
+        title: { text: context.title },
+        xaxis: {
+          title: context.xlabel,
+          range: [context.range[:x].first, context.range[:x].last]
+        },
+        yaxis: {
+          title: context.ylabel,
+          range: [context.range[:y].first, context.range[:y].last]
+        }
+      }
+      render_html(data, layout)
+    end
+
+    def render_html(data, layout)
+      id = div_id
+      <<~FRAGMENT
+        <script type='text/javascript' src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+        <div id="#{id}" style="#{div_style}"></div>
+        <script>
+          Plotly.plot('#{id}', #{JSON.dump(data)}, #{JSON.dump(layout)} );
+        </script>
+      FRAGMENT
+    end
+  end
+end

--- a/lib/charty/backends/plotly.rb
+++ b/lib/charty/backends/plotly.rb
@@ -6,6 +6,24 @@ module Charty
     Name = "plotly"
     attr_reader :context
 
+    class << self
+      attr_writer :chart_id, :with_api_load_tag, :plotly_src
+
+      def chart_id
+        @chart_id ||= 0
+      end
+
+      def with_api_load_tag
+        return @with_api_load_tag unless @with_api_load_tag.nil?
+
+        @with_api_load_tag = true
+      end
+
+      def plotly_src
+        @plotly_src ||= 'https://cdn.plot.ly/plotly-latest.min.js'
+      end
+    end
+
     def initilize
     end
 
@@ -22,6 +40,7 @@ module Charty
 
     def plot(plot, context)
       context = context
+      self.class.chart_id += 1
 
       case context.method
       when :bar
@@ -37,8 +56,15 @@ module Charty
 
     private
 
+    def plotly_load_tag
+      if self.class.with_api_load_tag
+        "<script type='text/javascript' src='#{self.class.plotly_src}'></script>"
+      else
+      end
+    end
+
     def div_id
-      "charty-plotly-#{SecureRandom.uuid}"
+      "charty-plotly-#{self.class.chart_id}"
     end
 
     def div_style
@@ -69,12 +95,11 @@ module Charty
     end
 
     def render_html(data, layout)
-      id = div_id
       <<~FRAGMENT
-        <script type='text/javascript' src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-        <div id="#{id}" style="#{div_style}"></div>
+        #{plotly_load_tag unless self.class.chart_id > 1}
+        <div id="#{div_id}" style="#{div_style}"></div>
         <script>
-          Plotly.plot('#{id}', #{JSON.dump(data)}, #{JSON.dump(layout)} );
+          Plotly.plot('#{div_id}', #{JSON.dump(data)}, #{JSON.dump(layout)} );
         </script>
       FRAGMENT
     end


### PR DESCRIPTION
# Summary

I'd like to introduce plotly backend to charty.

It based on [plotly.js](https://plot.ly/javascript/).

# Supported graph

Just now, below are supported.

- `bar`
- `curve`
- `scatter`

I wish to add another graphs.

# Test

```ruby
require 'charty'

charty = Charty::Plotter.new(:plotly)
bar = charty.bar do
  series [0,1,2,3,4], [10,40,20,90,70], label: "sample1"
  series [0,1,2,3,4], [90,80,70,60,50], label: "sample2"
  series [0,1,2,3,4,5,6,7,8], [50,60,20,30,10, 90, 0, 100, 50], label: "sample3"
  range x: 0..10, y: 1..100
  xlabel 'foo'
  ylabel 'bar'
  title 'bar plot'
end

curve = charty.curve do
  series [0,1,2,3,4], [10,40,20,90,70], label: "sample1"
  series [0,1,2,3,4], [90,80,70,60,50], label: "sample2"
  series [0,1,2,3,4,5,6,7,8], [50,60,20,30,10, 90, 0, 100, 50], label: "sample3"
  range x: 0..10, y: 1..100
  xlabel 'foo'
  ylabel 'bar'
end

scatter = charty.scatter do
  series 0..10, (0..1).step(0.1), label: 'sample1'
  series 0..5, (0..1).step(0.2), label: 'sample2'
  series [0, 1, 2, 3, 4], [0, -0.1, -0.5, -0.5, 0.1], label: 'sample3'
  range x: 0..10, y: -1..1
  # xlabel 'x label'
  # xlabel ''
  ylabel 'y label'
  title 'scatter sample'
end

File.open('test.html', 'w') do |f|
  f.puts '<html><body>'
  f.puts '<div style="width: 700px; height: 500px">'
  f.puts bar.render
  f.puts '</div>'
  f.puts '<div style="width: 700px; height: 500px">'
  f.puts curve.render
  f.puts '</div>'
  f.puts '<div style="width: 700px; height: 500px">'
  f.puts scatter.render
  f.puts '</div>'
  f.puts '</body></html>'
end
```

![_Users_shiratsuchi_src_github com_red-data-tools_charty_test html](https://user-images.githubusercontent.com/8451/60887957-9cbaf800-a290-11e9-8c7b-ca44559aba8c.png)
