### PR TITLE
Add curve and barh plot types for google_charts backend

### DIFF
--- a/examples/sample_google_chart.ipynb
+++ b/examples/sample_google_chart.ipynb
@@ -24,9 +24,9 @@
        "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
        "            google.charts.setOnLoadCallback(drawChart);\n",
        "            function drawChart() {\n",
-       "              const data = google.visualization.arrayToDataTable(\n",
-       "                [[\"foo\", \"\"], [0.0, 0.0], [0.1, 0.09983341664682815], [0.2, 0.19866933079506122], [0.30000000000000004, 0.2955202066613396], [0.4, 0.3894183423086505], [0.5, 0.479425538604203], [0.6000000000000001, 0.5646424733950355], [0.7000000000000001, 0.6442176872376911], [0.8, 0.7173560908995228], [0.9, 0.7833269096274834], [1.0, 0.8414709848078965], [1.1, 0.8912073600614354], [1.2000000000000002, 0.9320390859672264], [1.3, 0.963558185417193], [1.4000000000000001, 0.9854497299884603], [1.5, 0.9974949866040544], [1.6, 0.9995736030415051], [1.7000000000000002, 0.9916648104524686], [1.8, 0.9738476308781951], [1.9000000000000001, 0.9463000876874145], [2.0, 0.9092974268256817], [2.1, 0.8632093666488737], [2.2, 0.8084964038195901], [2.3000000000000003, 0.74570521217672], [2.4000000000000004, 0.6754631805511506], [2.5, 0.5984721441039565], [2.6, 0.5155013718214642], [2.7, 0.4273798802338298], [2.8000000000000003, 0.33498815015590466], [2.9000000000000004, 0.23924932921398198], [3.0, 0.1411200080598672], [3.1, 0.04158066243329049], [3.2, -0.058374143427580086], [3.3000000000000003, -0.15774569414324865], [3.4000000000000004, -0.25554110202683167], [3.5, -0.35078322768961984], [3.6, -0.44252044329485246], [3.7, -0.5298361409084934], [3.8000000000000003, -0.6118578909427193], [3.9000000000000004, -0.6877661591839741], [4.0, -0.7568024953079282], [4.1000000000000005, -0.8182771110644108], [4.2, -0.8715757724135882], [4.3, -0.9161659367494549], [4.4, -0.951602073889516], [4.5, -0.977530117665097], [4.6000000000000005, -0.9936910036334645], [4.7, -0.9999232575641008], [4.800000000000001, -0.9961646088358406], [4.9, -0.9824526126243325], [5.0, -0.9589242746631385], [5.1000000000000005, -0.9258146823277321], [5.2, -0.8834546557201531], [5.300000000000001, -0.8322674422239008], [5.4, -0.7727644875559871], [5.5, -0.7055403255703919], [5.6000000000000005, -0.6312666378723208], [5.7, -0.5506855425976376], [5.800000000000001, -0.4646021794137566], [5.9, -0.373876664830236], [6.0, -0.27941549819892586], [6.1000000000000005, -0.18216250427209502], [6.2, -0.0830894028174964], [6.300000000000001, 0.0168139004843506], [6.4, 0.11654920485049364], [6.5, 0.21511998808781552], [6.6000000000000005, 0.3115413635133787], [6.7, 0.4048499206165983], [6.800000000000001, 0.49411335113860894], [6.9, 0.5784397643882001], [7.0, 0.6569865987187891], [7.1000000000000005, 0.7289690401258765], [7.2, 0.7936678638491531], [7.300000000000001, 0.8504366206285648], [7.4, 0.8987080958116269], [7.5, 0.9379999767747389], [7.6000000000000005, 0.9679196720314865], [7.7, 0.9881682338770004], [7.800000000000001, 0.998543345374605], [7.9, 0.998941341839772], [8.0, 0.9893582466233818], [8.1, 0.9698898108450863], [8.200000000000001, 0.9407305566797726], [8.3, 0.9021718337562933], [8.4, 0.8545989080882804], [8.5, 0.7984871126234903], [8.6, 0.7343970978741133], [8.700000000000001, 0.662969230082182], [8.8, 0.5849171928917617], [8.9, 0.5010208564578846], [9.0, 0.4121184852417566], [9.1, 0.3190983623493521], [9.200000000000001, 0.22288991410024592], [9.3, 0.1244544235070617], [9.4, 0.024775425453357765], [9.5, -0.0751511204618093], [9.600000000000001, -0.1743267812229814], [9.700000000000001, -0.2717606264109442], [9.8, -0.3664791292519284], [10, -0.5440211108893698]]\n",
-       "              );\n",
+       "              const data = new google.visualization.DataTable();\n",
+       "              data.addColumn('number', 'foo');data.addColumn('number', '0');\n",
+       "              data.addRows([[0.0, 0.0], [0.1, 0.09983341664682815], [0.2, 0.19866933079506122], [0.30000000000000004, 0.2955202066613396], [0.4, 0.3894183423086505], [0.5, 0.479425538604203], [0.6000000000000001, 0.5646424733950355], [0.7000000000000001, 0.6442176872376911], [0.8, 0.7173560908995228], [0.9, 0.7833269096274834], [1.0, 0.8414709848078965], [1.1, 0.8912073600614354], [1.2000000000000002, 0.9320390859672264], [1.3, 0.963558185417193], [1.4000000000000001, 0.9854497299884603], [1.5, 0.9974949866040544], [1.6, 0.9995736030415051], [1.7000000000000002, 0.9916648104524686], [1.8, 0.9738476308781951], [1.9000000000000001, 0.9463000876874145], [2.0, 0.9092974268256817], [2.1, 0.8632093666488737], [2.2, 0.8084964038195901], [2.3000000000000003, 0.74570521217672], [2.4000000000000004, 0.6754631805511506], [2.5, 0.5984721441039565], [2.6, 0.5155013718214642], [2.7, 0.4273798802338298], [2.8000000000000003, 0.33498815015590466], [2.9000000000000004, 0.23924932921398198], [3.0, 0.1411200080598672], [3.1, 0.04158066243329049], [3.2, -0.058374143427580086], [3.3000000000000003, -0.15774569414324865], [3.4000000000000004, -0.25554110202683167], [3.5, -0.35078322768961984], [3.6, -0.44252044329485246], [3.7, -0.5298361409084934], [3.8000000000000003, -0.6118578909427193], [3.9000000000000004, -0.6877661591839741], [4.0, -0.7568024953079282], [4.1000000000000005, -0.8182771110644108], [4.2, -0.8715757724135882], [4.3, -0.9161659367494549], [4.4, -0.951602073889516], [4.5, -0.977530117665097], [4.6000000000000005, -0.9936910036334645], [4.7, -0.9999232575641008], [4.800000000000001, -0.9961646088358406], [4.9, -0.9824526126243325], [5.0, -0.9589242746631385], [5.1000000000000005, -0.9258146823277321], [5.2, -0.8834546557201531], [5.300000000000001, -0.8322674422239008], [5.4, -0.7727644875559871], [5.5, -0.7055403255703919], [5.6000000000000005, -0.6312666378723208], [5.7, -0.5506855425976376], [5.800000000000001, -0.4646021794137566], [5.9, -0.373876664830236], [6.0, -0.27941549819892586], [6.1000000000000005, -0.18216250427209502], [6.2, -0.0830894028174964], [6.300000000000001, 0.0168139004843506], [6.4, 0.11654920485049364], [6.5, 0.21511998808781552], [6.6000000000000005, 0.3115413635133787], [6.7, 0.4048499206165983], [6.800000000000001, 0.49411335113860894], [6.9, 0.5784397643882001], [7.0, 0.6569865987187891], [7.1000000000000005, 0.7289690401258765], [7.2, 0.7936678638491531], [7.300000000000001, 0.8504366206285648], [7.4, 0.8987080958116269], [7.5, 0.9379999767747389], [7.6000000000000005, 0.9679196720314865], [7.7, 0.9881682338770004], [7.800000000000001, 0.998543345374605], [7.9, 0.998941341839772], [8.0, 0.9893582466233818], [8.1, 0.9698898108450863], [8.200000000000001, 0.9407305566797726], [8.3, 0.9021718337562933], [8.4, 0.8545989080882804], [8.5, 0.7984871126234903], [8.6, 0.7343970978741133], [8.700000000000001, 0.662969230082182], [8.8, 0.5849171928917617], [8.9, 0.5010208564578846], [9.0, 0.4121184852417566], [9.1, 0.3190983623493521], [9.200000000000001, 0.22288991410024592], [9.3, 0.1244544235070617], [9.4, 0.024775425453357765], [9.5, -0.0751511204618093], [9.600000000000001, -0.1743267812229814], [9.700000000000001, -0.2717606264109442], [9.8, -0.3664791292519284], [10, -0.5440211108893698]])\n",
        "\n",
        "              const view = new google.visualization.DataView(data);\n",
        "\n",
@@ -55,7 +55,7 @@
        "          <div id=\"LineChart-1\" style=\"width: 900px; height: 300px;\"></div>\n"
       ],
       "text/plain": [
-       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"\\\"], [0.0, 0.0], [0.1, 0.09983341664682815], [0.2, 0.19866933079506122], [0.30000000000000004, 0.2955202066613396], [0.4, 0.3894183423086505], [0.5, 0.479425538604203], [0.6000000000000001, 0.5646424733950355], [0.7000000000000001, 0.6442176872376911], [0.8, 0.7173560908995228], [0.9, 0.7833269096274834], [1.0, 0.8414709848078965], [1.1, 0.8912073600614354], [1.2000000000000002, 0.9320390859672264], [1.3, 0.963558185417193], [1.4000000000000001, 0.9854497299884603], [1.5, 0.9974949866040544], [1.6, 0.9995736030415051], [1.7000000000000002, 0.9916648104524686], [1.8, 0.9738476308781951], [1.9000000000000001, 0.9463000876874145], [2.0, 0.9092974268256817], [2.1, 0.8632093666488737], [2.2, 0.8084964038195901], [2.3000000000000003, 0.74570521217672], [2.4000000000000004, 0.6754631805511506], [2.5, 0.5984721441039565], [2.6, 0.5155013718214642], [2.7, 0.4273798802338298], [2.8000000000000003, 0.33498815015590466], [2.9000000000000004, 0.23924932921398198], [3.0, 0.1411200080598672], [3.1, 0.04158066243329049], [3.2, -0.058374143427580086], [3.3000000000000003, -0.15774569414324865], [3.4000000000000004, -0.25554110202683167], [3.5, -0.35078322768961984], [3.6, -0.44252044329485246], [3.7, -0.5298361409084934], [3.8000000000000003, -0.6118578909427193], [3.9000000000000004, -0.6877661591839741], [4.0, -0.7568024953079282], [4.1000000000000005, -0.8182771110644108], [4.2, -0.8715757724135882], [4.3, -0.9161659367494549], [4.4, -0.951602073889516], [4.5, -0.977530117665097], [4.6000000000000005, -0.9936910036334645], [4.7, -0.9999232575641008], [4.800000000000001, -0.9961646088358406], [4.9, -0.9824526126243325], [5.0, -0.9589242746631385], [5.1000000000000005, -0.9258146823277321], [5.2, -0.8834546557201531], [5.300000000000001, -0.8322674422239008], [5.4, -0.7727644875559871], [5.5, -0.7055403255703919], [5.6000000000000005, -0.6312666378723208], [5.7, -0.5506855425976376], [5.800000000000001, -0.4646021794137566], [5.9, -0.373876664830236], [6.0, -0.27941549819892586], [6.1000000000000005, -0.18216250427209502], [6.2, -0.0830894028174964], [6.300000000000001, 0.0168139004843506], [6.4, 0.11654920485049364], [6.5, 0.21511998808781552], [6.6000000000000005, 0.3115413635133787], [6.7, 0.4048499206165983], [6.800000000000001, 0.49411335113860894], [6.9, 0.5784397643882001], [7.0, 0.6569865987187891], [7.1000000000000005, 0.7289690401258765], [7.2, 0.7936678638491531], [7.300000000000001, 0.8504366206285648], [7.4, 0.8987080958116269], [7.5, 0.9379999767747389], [7.6000000000000005, 0.9679196720314865], [7.7, 0.9881682338770004], [7.800000000000001, 0.998543345374605], [7.9, 0.998941341839772], [8.0, 0.9893582466233818], [8.1, 0.9698898108450863], [8.200000000000001, 0.9407305566797726], [8.3, 0.9021718337562933], [8.4, 0.8545989080882804], [8.5, 0.7984871126234903], [8.6, 0.7343970978741133], [8.700000000000001, 0.662969230082182], [8.8, 0.5849171928917617], [8.9, 0.5010208564578846], [9.0, 0.4121184852417566], [9.1, 0.3190983623493521], [9.200000000000001, 0.22288991410024592], [9.3, 0.1244544235070617], [9.4, 0.024775425453357765], [9.5, -0.0751511204618093], [9.600000000000001, -0.1743267812229814], [9.700000000000001, -0.2717606264109442], [9.8, -0.3664791292519284], [10, -0.5440211108893698]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"\\\",\\n                vAxis: {\\n                  title: \\\"bar\\\",\\n                  viewWindow: {\\n                    max: 1,\\n                    min: -1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.LineChart(document.getElementById(\\\"LineChart-1\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"LineChart-1\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = new google.visualization.DataTable();\\n              data.addColumn('number', 'foo');data.addColumn('number', '0');\\n              data.addRows([[0.0, 0.0], [0.1, 0.09983341664682815], [0.2, 0.19866933079506122], [0.30000000000000004, 0.2955202066613396], [0.4, 0.3894183423086505], [0.5, 0.479425538604203], [0.6000000000000001, 0.5646424733950355], [0.7000000000000001, 0.6442176872376911], [0.8, 0.7173560908995228], [0.9, 0.7833269096274834], [1.0, 0.8414709848078965], [1.1, 0.8912073600614354], [1.2000000000000002, 0.9320390859672264], [1.3, 0.963558185417193], [1.4000000000000001, 0.9854497299884603], [1.5, 0.9974949866040544], [1.6, 0.9995736030415051], [1.7000000000000002, 0.9916648104524686], [1.8, 0.9738476308781951], [1.9000000000000001, 0.9463000876874145], [2.0, 0.9092974268256817], [2.1, 0.8632093666488737], [2.2, 0.8084964038195901], [2.3000000000000003, 0.74570521217672], [2.4000000000000004, 0.6754631805511506], [2.5, 0.5984721441039565], [2.6, 0.5155013718214642], [2.7, 0.4273798802338298], [2.8000000000000003, 0.33498815015590466], [2.9000000000000004, 0.23924932921398198], [3.0, 0.1411200080598672], [3.1, 0.04158066243329049], [3.2, -0.058374143427580086], [3.3000000000000003, -0.15774569414324865], [3.4000000000000004, -0.25554110202683167], [3.5, -0.35078322768961984], [3.6, -0.44252044329485246], [3.7, -0.5298361409084934], [3.8000000000000003, -0.6118578909427193], [3.9000000000000004, -0.6877661591839741], [4.0, -0.7568024953079282], [4.1000000000000005, -0.8182771110644108], [4.2, -0.8715757724135882], [4.3, -0.9161659367494549], [4.4, -0.951602073889516], [4.5, -0.977530117665097], [4.6000000000000005, -0.9936910036334645], [4.7, -0.9999232575641008], [4.800000000000001, -0.9961646088358406], [4.9, -0.9824526126243325], [5.0, -0.9589242746631385], [5.1000000000000005, -0.9258146823277321], [5.2, -0.8834546557201531], [5.300000000000001, -0.8322674422239008], [5.4, -0.7727644875559871], [5.5, -0.7055403255703919], [5.6000000000000005, -0.6312666378723208], [5.7, -0.5506855425976376], [5.800000000000001, -0.4646021794137566], [5.9, -0.373876664830236], [6.0, -0.27941549819892586], [6.1000000000000005, -0.18216250427209502], [6.2, -0.0830894028174964], [6.300000000000001, 0.0168139004843506], [6.4, 0.11654920485049364], [6.5, 0.21511998808781552], [6.6000000000000005, 0.3115413635133787], [6.7, 0.4048499206165983], [6.800000000000001, 0.49411335113860894], [6.9, 0.5784397643882001], [7.0, 0.6569865987187891], [7.1000000000000005, 0.7289690401258765], [7.2, 0.7936678638491531], [7.300000000000001, 0.8504366206285648], [7.4, 0.8987080958116269], [7.5, 0.9379999767747389], [7.6000000000000005, 0.9679196720314865], [7.7, 0.9881682338770004], [7.800000000000001, 0.998543345374605], [7.9, 0.998941341839772], [8.0, 0.9893582466233818], [8.1, 0.9698898108450863], [8.200000000000001, 0.9407305566797726], [8.3, 0.9021718337562933], [8.4, 0.8545989080882804], [8.5, 0.7984871126234903], [8.6, 0.7343970978741133], [8.700000000000001, 0.662969230082182], [8.8, 0.5849171928917617], [8.9, 0.5010208564578846], [9.0, 0.4121184852417566], [9.1, 0.3190983623493521], [9.200000000000001, 0.22288991410024592], [9.3, 0.1244544235070617], [9.4, 0.024775425453357765], [9.5, -0.0751511204618093], [9.600000000000001, -0.1743267812229814], [9.700000000000001, -0.2717606264109442], [9.8, -0.3664791292519284], [10, -0.5440211108893698]])\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"\\\",\\n                vAxis: {\\n                  title: \\\"bar\\\",\\n                  viewWindow: {\\n                    max: 1,\\n                    min: -1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.LineChart(document.getElementById(\\\"LineChart-1\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"LineChart-1\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
       ]
      },
      "metadata": {},
@@ -86,9 +86,9 @@
        "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
        "            google.charts.setOnLoadCallback(drawChart);\n",
        "            function drawChart() {\n",
-       "              const data = google.visualization.arrayToDataTable(\n",
-       "                [[\"foo\", \"\", \"\", \"\"], [0, 10, 90, 50], [1, 40, 80, 60], [2, 20, 70, 20], [3, 90, 60, 30], [4, 70, 50, 10], [5, \"null\", \"null\", 90], [6, \"null\", \"null\", 0], [7, \"null\", \"null\", 100], [8, \"null\", \"null\", 50]]\n",
-       "              );\n",
+       "              const data = new google.visualization.DataTable();\n",
+       "              data.addColumn('number', 'foo');data.addColumn('number', '0');data.addColumn('number', '1');data.addColumn('number', '2');\n",
+       "              data.addRows([[0, 10, 90, 50], [1, 40, 80, 60], [2, 20, 70, 20], [3, 90, 60, 30], [4, 70, 50, 10], [5, null, null, 90], [6, null, null, 0], [7, null, null, 100], [8, null, null, 50]])\n",
        "\n",
        "              const view = new google.visualization.DataView(data);\n",
        "\n",
@@ -117,7 +117,7 @@
        "          <div id=\"LineChart-2\" style=\"width: 900px; height: 300px;\"></div>\n"
       ],
       "text/plain": [
-       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"\\\", \\\"\\\", \\\"\\\"], [0, 10, 90, 50], [1, 40, 80, 60], [2, 20, 70, 20], [3, 90, 60, 30], [4, 70, 50, 10], [5, \\\"null\\\", \\\"null\\\", 90], [6, \\\"null\\\", \\\"null\\\", 0], [7, \\\"null\\\", \\\"null\\\", 100], [8, \\\"null\\\", \\\"null\\\", 50]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"\\\",\\n                vAxis: {\\n                  title: \\\"bar\\\",\\n                  viewWindow: {\\n                    max: 100,\\n                    min: 1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.LineChart(document.getElementById(\\\"LineChart-2\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"LineChart-2\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = new google.visualization.DataTable();\\n              data.addColumn('number', 'foo');data.addColumn('number', '0');data.addColumn('number', '1');data.addColumn('number', '2');\\n              data.addRows([[0, 10, 90, 50], [1, 40, 80, 60], [2, 20, 70, 20], [3, 90, 60, 30], [4, 70, 50, 10], [5, null, null, 90], [6, null, null, 0], [7, null, null, 100], [8, null, null, 50]])\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"\\\",\\n                vAxis: {\\n                  title: \\\"bar\\\",\\n                  viewWindow: {\\n                    max: 100,\\n                    min: 1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.LineChart(document.getElementById(\\\"LineChart-2\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"LineChart-2\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
       ]
      },
      "metadata": {},
@@ -150,38 +150,38 @@
        "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
        "            google.charts.setOnLoadCallback(drawChart);\n",
        "            function drawChart() {\n",
-       "              const data = google.visualization.arrayToDataTable(\n",
-       "                [[\"foo\", \"\", \"\"], [\"0\", 10, 30], [\"1\", 20, 40], [\"2\", 70, 50], [\"4\", 60, \"null\"]]\n",
-       "              );\n",
+       "              const data = new google.visualization.DataTable();\n",
+       "              data.addColumn('string', 'foo');data.addColumn('number', '0');data.addColumn('number', '1');data.addColumn('number', '2');\n",
+       "              data.addRows([[\"0\", 10, 90, 50], [\"1\", 40, 80, 60], [\"2\", 20, 70, 20], [\"3\", 90, 60, 30], [\"4\", 70, 50, 10], [\"5\", null, null, 90], [\"6\", null, null, 0], [\"7\", null, null, 100], [\"8\", null, null, 50]])\n",
        "\n",
        "              const view = new google.visualization.DataView(data);\n",
        "\n",
        "              const options = {\n",
-       "                title: \"this is the title\",\n",
+       "                title: \"bar plot\",\n",
        "                vAxis: {\n",
-       "                  title: \"bara\",\n",
+       "                  title: \"bar\",\n",
        "                  viewWindow: {\n",
-       "                    max: null,\n",
-       "                    min: null,\n",
+       "                    max: 100,\n",
+       "                    min: 1,\n",
        "                  },\n",
        "                },\n",
        "                hAxis: {\n",
        "                  title: \"foo\",\n",
        "                  viewWindow: {\n",
-       "                    max: null,\n",
-       "                    min: null,\n",
+       "                    max: 10,\n",
+       "                    min: 0,\n",
        "                  }\n",
        "                },\n",
        "                legend: { position: \"none\" },\n",
        "              };\n",
-       "              const chart = new google.visualization.BarChart(document.getElementById(\"BarChart-3\"));\n",
+       "              const chart = new google.visualization.ColumnChart(document.getElementById(\"ColumnChart-3\"));\n",
        "              chart.draw(view, options);\n",
        "            }\n",
        "          </script>\n",
-       "          <div id=\"BarChart-3\" style=\"width: 900px; height: 300px;\"></div>\n"
+       "          <div id=\"ColumnChart-3\" style=\"width: 900px; height: 300px;\"></div>\n"
       ],
       "text/plain": [
-       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"\\\", \\\"\\\"], [\\\"0\\\", 10, 30], [\\\"1\\\", 20, 40], [\\\"2\\\", 70, 50], [\\\"4\\\", 60, \\\"null\\\"]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"this is the title\\\",\\n                vAxis: {\\n                  title: \\\"bara\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BarChart(document.getElementById(\\\"BarChart-3\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"BarChart-3\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = new google.visualization.DataTable();\\n              data.addColumn('string', 'foo');data.addColumn('number', '0');data.addColumn('number', '1');data.addColumn('number', '2');\\n              data.addRows([[\\\"0\\\", 10, 90, 50], [\\\"1\\\", 40, 80, 60], [\\\"2\\\", 20, 70, 20], [\\\"3\\\", 90, 60, 30], [\\\"4\\\", 70, 50, 10], [\\\"5\\\", null, null, 90], [\\\"6\\\", null, null, 0], [\\\"7\\\", null, null, 100], [\\\"8\\\", null, null, 50]])\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"bar plot\\\",\\n                vAxis: {\\n                  title: \\\"bar\\\",\\n                  viewWindow: {\\n                    max: 100,\\n                    min: 1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.ColumnChart(document.getElementById(\\\"ColumnChart-3\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"ColumnChart-3\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
       ]
      },
      "metadata": {},
@@ -190,11 +190,13 @@
    ],
    "source": [
     "bar = charty.bar do\n",
+    "  series [0,1,2,3,4], [10,40,20,90,70]\n",
+    "  series [0,1,2,3,4], [90,80,70,60,50]\n",
+    "  series [0,1,2,3,4,5,6,7,8], [50,60,20,30,10, 90, 0, 100, 50]\n",
+    "  range x: 0..10, y: 1..100\n",
     "  xlabel 'foo'\n",
-    "  ylabel 'bara'\n",
-    "  series [0, 1, 4,  2], [10, 20, 60, 70]\n",
-    "  series [0, 1, 2], [30, 40, 50]\n",
-    "  title 'this is the title'\n",
+    "  ylabel 'bar'\n",
+    "  title 'bar plot'\n",
     "end\n",
     "IRuby.display(IRuby.html(bar.render))\n",
     "nil"
@@ -213,9 +215,74 @@
        "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
        "            google.charts.setOnLoadCallback(drawChart);\n",
        "            function drawChart() {\n",
-       "              const data = google.visualization.arrayToDataTable(\n",
-       "                [[\"\", \"sample1\", \"sample2\", \"\"], [\"0\", 0.0, 0.0, 0], [\"1\", 0.1, 0.2, -0.1], [\"2\", 0.2, 0.4, -0.5], [\"3\", 0.30000000000000004, 0.6000000000000001, -0.5], [\"4\", 0.4, 0.8, 0.1], [\"5\", 0.5, 1.0, \"null\"], [\"6\", 0.6000000000000001, \"null\", \"null\"], [\"7\", 0.7000000000000001, \"null\", \"null\"], [\"8\", 0.8, \"null\", \"null\"], [\"9\", 0.9, \"null\", \"null\"], [\"10\", 1.0, \"null\", \"null\"]]\n",
-       "              );\n",
+       "              const data = new google.visualization.DataTable();\n",
+       "              data.addColumn('string', 'foo');data.addColumn('number', '0');data.addColumn('number', '1');data.addColumn('number', '2');\n",
+       "              data.addRows([[\"4\", 70, null, 10], [\"123412341234\", 10, null, null], [\"1234523452345\", 40, null, null], [\"234563456345634\", 20, null, null], [\"3456745674567\", 90, null, null], [\"a\", null, 90, null], [\"b\", null, 80, null], [\"c\", null, 70, null], [\"d\", null, 60, null], [\"e\", null, 50, null], [\"0\", null, null, 50], [\"1\", null, null, 60], [\"2\", null, null, 20], [\"3\", null, null, 30], [\"5\", null, null, 90], [\"6\", null, null, 0], [\"7\", null, null, 100], [\"8\", null, null, 50]])\n",
+       "\n",
+       "              const view = new google.visualization.DataView(data);\n",
+       "\n",
+       "              const options = {\n",
+       "                title: \"bar plot\",\n",
+       "                vAxis: {\n",
+       "                  title: \"bar\",\n",
+       "                  viewWindow: {\n",
+       "                    max: 10,\n",
+       "                    min: 0,\n",
+       "                  },\n",
+       "                },\n",
+       "                hAxis: {\n",
+       "                  title: \"foo\",\n",
+       "                  viewWindow: {\n",
+       "                    max: 100,\n",
+       "                    min: 1,\n",
+       "                  }\n",
+       "                },\n",
+       "                legend: { position: \"none\" },\n",
+       "              };\n",
+       "              const chart = new google.visualization.BarChart(document.getElementById(\"BarChart-4\"));\n",
+       "              chart.draw(view, options);\n",
+       "            }\n",
+       "          </script>\n",
+       "          <div id=\"BarChart-4\" style=\"width: 900px; height: 300px;\"></div>\n"
+      ],
+      "text/plain": [
+       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = new google.visualization.DataTable();\\n              data.addColumn('string', 'foo');data.addColumn('number', '0');data.addColumn('number', '1');data.addColumn('number', '2');\\n              data.addRows([[\\\"4\\\", 70, null, 10], [\\\"123412341234\\\", 10, null, null], [\\\"1234523452345\\\", 40, null, null], [\\\"234563456345634\\\", 20, null, null], [\\\"3456745674567\\\", 90, null, null], [\\\"a\\\", null, 90, null], [\\\"b\\\", null, 80, null], [\\\"c\\\", null, 70, null], [\\\"d\\\", null, 60, null], [\\\"e\\\", null, 50, null], [\\\"0\\\", null, null, 50], [\\\"1\\\", null, null, 60], [\\\"2\\\", null, null, 20], [\\\"3\\\", null, null, 30], [\\\"5\\\", null, null, 90], [\\\"6\\\", null, null, 0], [\\\"7\\\", null, null, 100], [\\\"8\\\", null, null, 50]])\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"bar plot\\\",\\n                vAxis: {\\n                  title: \\\"bar\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: 100,\\n                    min: 1,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BarChart(document.getElementById(\\\"BarChart-4\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"BarChart-4\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "barh = charty.barh do\n",
+    "  series [123412341234,1234523452345,234563456345634,3456745674567,\"4\"], [10,40,20,90,70]\n",
+    "  series [\"a\",\"b\",\"c\",\"d\",\"e\"], [90,80,70,60,50]\n",
+    "  series [\"0\",\"1\",\"2\",\"3\",\"4\",\"5\",\"6\",\"7\",\"8\"], [50,60,20,30,10, 90, 0, 100, 50]\n",
+    "  range x: 0..10, y: 1..100\n",
+    "  xlabel 'foo'\n",
+    "  ylabel 'bar'\n",
+    "  title 'bar plot'\n",
+    "end\n",
+    "IRuby.display(IRuby.html(barh.render))\n",
+    "nil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "          \n",
+       "          <script type=\"text/javascript\">\n",
+       "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
+       "            google.charts.setOnLoadCallback(drawChart);\n",
+       "            function drawChart() {\n",
+       "              const data = new google.visualization.DataTable();\n",
+       "              data.addColumn('string', '');data.addColumn('number', 'sample1');data.addColumn('number', 'sample2');data.addColumn('number', '2');\n",
+       "              data.addRows([[\"0\", 0.0, 0.0, 0], [\"1\", 0.1, 0.2, -0.1], [\"2\", 0.2, 0.4, -0.5], [\"3\", 0.30000000000000004, 0.6000000000000001, -0.5], [\"4\", 0.4, 0.8, 0.1], [\"5\", 0.5, 1.0, null], [\"6\", 0.6000000000000001, null, null], [\"7\", 0.7000000000000001, null, null], [\"8\", 0.8, null, null], [\"9\", 0.9, null, null], [\"10\", 1.0, null, null]])\n",
        "\n",
        "              const view = new google.visualization.DataView(data);\n",
        "\n",
@@ -237,14 +304,14 @@
        "                },\n",
        "                legend: { position: \"none\" },\n",
        "              };\n",
-       "              const chart = new google.visualization.ScatterChart(document.getElementById(\"ScatterChart-4\"));\n",
+       "              const chart = new google.visualization.ScatterChart(document.getElementById(\"ScatterChart-5\"));\n",
        "              chart.draw(view, options);\n",
        "            }\n",
        "          </script>\n",
-       "          <div id=\"ScatterChart-4\" style=\"width: 900px; height: 300px;\"></div>\n"
+       "          <div id=\"ScatterChart-5\" style=\"width: 900px; height: 300px;\"></div>\n"
       ],
       "text/plain": [
-       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"\\\", \\\"sample1\\\", \\\"sample2\\\", \\\"\\\"], [\\\"0\\\", 0.0, 0.0, 0], [\\\"1\\\", 0.1, 0.2, -0.1], [\\\"2\\\", 0.2, 0.4, -0.5], [\\\"3\\\", 0.30000000000000004, 0.6000000000000001, -0.5], [\\\"4\\\", 0.4, 0.8, 0.1], [\\\"5\\\", 0.5, 1.0, \\\"null\\\"], [\\\"6\\\", 0.6000000000000001, \\\"null\\\", \\\"null\\\"], [\\\"7\\\", 0.7000000000000001, \\\"null\\\", \\\"null\\\"], [\\\"8\\\", 0.8, \\\"null\\\", \\\"null\\\"], [\\\"9\\\", 0.9, \\\"null\\\", \\\"null\\\"], [\\\"10\\\", 1.0, \\\"null\\\", \\\"null\\\"]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"scatter sample\\\",\\n                vAxis: {\\n                  title: \\\"y label\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.ScatterChart(document.getElementById(\\\"ScatterChart-4\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"ScatterChart-4\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = new google.visualization.DataTable();\\n              data.addColumn('string', '');data.addColumn('number', 'sample1');data.addColumn('number', 'sample2');data.addColumn('number', '2');\\n              data.addRows([[\\\"0\\\", 0.0, 0.0, 0], [\\\"1\\\", 0.1, 0.2, -0.1], [\\\"2\\\", 0.2, 0.4, -0.5], [\\\"3\\\", 0.30000000000000004, 0.6000000000000001, -0.5], [\\\"4\\\", 0.4, 0.8, 0.1], [\\\"5\\\", 0.5, 1.0, null], [\\\"6\\\", 0.6000000000000001, null, null], [\\\"7\\\", 0.7000000000000001, null, null], [\\\"8\\\", 0.8, null, null], [\\\"9\\\", 0.9, null, null], [\\\"10\\\", 1.0, null, null]])\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"scatter sample\\\",\\n                vAxis: {\\n                  title: \\\"y label\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.ScatterChart(document.getElementById(\\\"ScatterChart-5\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"ScatterChart-5\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
       ]
      },
      "metadata": {},
@@ -265,7 +332,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -276,9 +343,14 @@
        "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
        "            google.charts.setOnLoadCallback(drawChart);\n",
        "            function drawChart() {\n",
-       "              const data = google.visualization.arrayToDataTable(\n",
-       "                [[\"ID\", \"X\", \"Y\", \"GROUP\", \"SIZE\"], [\"\", 0, 0.0, \"sample1\", 10], [\"\", 1, 0.1, \"sample1\", 100], [\"\", 2, 0.2, \"sample1\", 1000], [\"\", 3, 0.30000000000000004, \"sample1\", 20], [\"\", 4, 0.4, \"sample1\", 200], [\"\", 5, 0.5, \"sample1\", 2000], [\"\", 6, 0.6000000000000001, \"sample1\", 5], [\"\", 7, 0.7000000000000001, \"sample1\", 50], [\"\", 8, 0.8, \"sample1\", 500], [\"\", 9, 0.9, \"sample1\", 4], [\"\", 10, 1.0, \"sample1\", 40], [\"\", 0, 0.0, \"sample2\", 1], [\"\", 1, 0.2, \"sample2\", 10], [\"\", 2, 0.4, \"sample2\", 100], [\"\", 3, 0.6000000000000001, \"sample2\", 1000], [\"\", 4, 0.8, \"sample2\", 500], [\"\", 5, 1.0, \"sample2\", 100], [\"\", 0, 0, 2, 40], [\"\", 1, -0.1, 2, 30], [\"\", 2, -0.5, 2, 200], [\"\", 3, -0.5, 2, 10], [\"\", 4, 0.1, 2, 5]]\n",
-       "              );\n",
+       "              const data = new google.visualization.DataTable();\n",
+       "                          data.addColumn('string', 'ID');\n",
+       "            data.addColumn('number', 'X');\n",
+       "            data.addColumn('number', 'Y');\n",
+       "            data.addColumn('string', 'GROUP');\n",
+       "            data.addColumn('number', 'SIZE');\n",
+       "\n",
+       "              data.addRows([[\"\", 0, 0.0, \"sample1\", 10], [\"\", 1, 0.1, \"sample1\", 100], [\"\", 2, 0.2, \"sample1\", 1000], [\"\", 3, 0.30000000000000004, \"sample1\", 20], [\"\", 4, 0.4, \"sample1\", 200], [\"\", 5, 0.5, \"sample1\", 2000], [\"\", 6, 0.6000000000000001, \"sample1\", 5], [\"\", 7, 0.7000000000000001, \"sample1\", 50], [\"\", 8, 0.8, \"sample1\", 500], [\"\", 9, 0.9, \"sample1\", 4], [\"\", 10, 1.0, \"sample1\", 40], [\"\", 0, 0.0, \"sample2\", 1], [\"\", 1, 0.2, \"sample2\", 10], [\"\", 2, 0.4, \"sample2\", 100], [\"\", 3, 0.6000000000000001, \"sample2\", 1000], [\"\", 4, 0.8, \"sample2\", 500], [\"\", 5, 1.0, \"sample2\", 100], [\"\", 0, 0, \"2\", 40], [\"\", 1, -0.1, \"2\", 30], [\"\", 2, -0.5, \"2\", 200], [\"\", 3, -0.5, \"2\", 10], [\"\", 4, 0.1, \"2\", 5]])\n",
        "\n",
        "              const view = new google.visualization.DataView(data);\n",
        "\n",
@@ -300,14 +372,14 @@
        "                },\n",
        "                legend: { position: \"none\" },\n",
        "              };\n",
-       "              const chart = new google.visualization.BubbleChart(document.getElementById(\"BubbleChart-5\"));\n",
+       "              const chart = new google.visualization.BubbleChart(document.getElementById(\"BubbleChart-6\"));\n",
        "              chart.draw(view, options);\n",
        "            }\n",
        "          </script>\n",
-       "          <div id=\"BubbleChart-5\" style=\"width: 900px; height: 300px;\"></div>\n"
+       "          <div id=\"BubbleChart-6\" style=\"width: 900px; height: 300px;\"></div>\n"
       ],
       "text/plain": [
-       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"ID\\\", \\\"X\\\", \\\"Y\\\", \\\"GROUP\\\", \\\"SIZE\\\"], [\\\"\\\", 0, 0.0, \\\"sample1\\\", 10], [\\\"\\\", 1, 0.1, \\\"sample1\\\", 100], [\\\"\\\", 2, 0.2, \\\"sample1\\\", 1000], [\\\"\\\", 3, 0.30000000000000004, \\\"sample1\\\", 20], [\\\"\\\", 4, 0.4, \\\"sample1\\\", 200], [\\\"\\\", 5, 0.5, \\\"sample1\\\", 2000], [\\\"\\\", 6, 0.6000000000000001, \\\"sample1\\\", 5], [\\\"\\\", 7, 0.7000000000000001, \\\"sample1\\\", 50], [\\\"\\\", 8, 0.8, \\\"sample1\\\", 500], [\\\"\\\", 9, 0.9, \\\"sample1\\\", 4], [\\\"\\\", 10, 1.0, \\\"sample1\\\", 40], [\\\"\\\", 0, 0.0, \\\"sample2\\\", 1], [\\\"\\\", 1, 0.2, \\\"sample2\\\", 10], [\\\"\\\", 2, 0.4, \\\"sample2\\\", 100], [\\\"\\\", 3, 0.6000000000000001, \\\"sample2\\\", 1000], [\\\"\\\", 4, 0.8, \\\"sample2\\\", 500], [\\\"\\\", 5, 1.0, \\\"sample2\\\", 100], [\\\"\\\", 0, 0, 2, 40], [\\\"\\\", 1, -0.1, 2, 30], [\\\"\\\", 2, -0.5, 2, 200], [\\\"\\\", 3, -0.5, 2, 10], [\\\"\\\", 4, 0.1, 2, 5]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"bubble sample\\\",\\n                vAxis: {\\n                  title: \\\"y label\\\",\\n                  viewWindow: {\\n                    max: 1,\\n                    min: -1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"x label\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BubbleChart(document.getElementById(\\\"BubbleChart-5\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"BubbleChart-5\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = new google.visualization.DataTable();\\n                          data.addColumn('string', 'ID');\\n            data.addColumn('number', 'X');\\n            data.addColumn('number', 'Y');\\n            data.addColumn('string', 'GROUP');\\n            data.addColumn('number', 'SIZE');\\n\\n              data.addRows([[\\\"\\\", 0, 0.0, \\\"sample1\\\", 10], [\\\"\\\", 1, 0.1, \\\"sample1\\\", 100], [\\\"\\\", 2, 0.2, \\\"sample1\\\", 1000], [\\\"\\\", 3, 0.30000000000000004, \\\"sample1\\\", 20], [\\\"\\\", 4, 0.4, \\\"sample1\\\", 200], [\\\"\\\", 5, 0.5, \\\"sample1\\\", 2000], [\\\"\\\", 6, 0.6000000000000001, \\\"sample1\\\", 5], [\\\"\\\", 7, 0.7000000000000001, \\\"sample1\\\", 50], [\\\"\\\", 8, 0.8, \\\"sample1\\\", 500], [\\\"\\\", 9, 0.9, \\\"sample1\\\", 4], [\\\"\\\", 10, 1.0, \\\"sample1\\\", 40], [\\\"\\\", 0, 0.0, \\\"sample2\\\", 1], [\\\"\\\", 1, 0.2, \\\"sample2\\\", 10], [\\\"\\\", 2, 0.4, \\\"sample2\\\", 100], [\\\"\\\", 3, 0.6000000000000001, \\\"sample2\\\", 1000], [\\\"\\\", 4, 0.8, \\\"sample2\\\", 500], [\\\"\\\", 5, 1.0, \\\"sample2\\\", 100], [\\\"\\\", 0, 0, \\\"2\\\", 40], [\\\"\\\", 1, -0.1, \\\"2\\\", 30], [\\\"\\\", 2, -0.5, \\\"2\\\", 200], [\\\"\\\", 3, -0.5, \\\"2\\\", 10], [\\\"\\\", 4, 0.1, \\\"2\\\", 5]])\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"bubble sample\\\",\\n                vAxis: {\\n                  title: \\\"y label\\\",\\n                  viewWindow: {\\n                    max: 1,\\n                    min: -1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"x label\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BubbleChart(document.getElementById(\\\"BubbleChart-6\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"BubbleChart-6\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
       ]
      },
      "metadata": {},
@@ -327,6 +399,13 @@
     "IRuby.display(IRuby.html(bubble.render))\n",
     "nil"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/sample_google_chart.ipynb
+++ b/examples/sample_google_chart.ipynb
@@ -4,21 +4,11 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "#<Charty::Plotter:0x00007fc44239a540 @plotter_adapter=#<Charty::GoogleChart:0x00007fc4440b3780>>"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "require 'charty'\n",
-    "charty = Charty::Plotter.new(:google_chart)"
+    "charty = Charty::Plotter.new(:google_chart)\n",
+    "nil"
    ]
   },
   {
@@ -30,6 +20,132 @@
      "data": {
       "text/html": [
        "          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\n",
+       "          <script type=\"text/javascript\">\n",
+       "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
+       "            google.charts.setOnLoadCallback(drawChart);\n",
+       "            function drawChart() {\n",
+       "              const data = google.visualization.arrayToDataTable(\n",
+       "                [[\"foo\", \"\"], [0.0, 0.0], [0.1, 0.09983341664682815], [0.2, 0.19866933079506122], [0.30000000000000004, 0.2955202066613396], [0.4, 0.3894183423086505], [0.5, 0.479425538604203], [0.6000000000000001, 0.5646424733950355], [0.7000000000000001, 0.6442176872376911], [0.8, 0.7173560908995228], [0.9, 0.7833269096274834], [1.0, 0.8414709848078965], [1.1, 0.8912073600614354], [1.2000000000000002, 0.9320390859672264], [1.3, 0.963558185417193], [1.4000000000000001, 0.9854497299884603], [1.5, 0.9974949866040544], [1.6, 0.9995736030415051], [1.7000000000000002, 0.9916648104524686], [1.8, 0.9738476308781951], [1.9000000000000001, 0.9463000876874145], [2.0, 0.9092974268256817], [2.1, 0.8632093666488737], [2.2, 0.8084964038195901], [2.3000000000000003, 0.74570521217672], [2.4000000000000004, 0.6754631805511506], [2.5, 0.5984721441039565], [2.6, 0.5155013718214642], [2.7, 0.4273798802338298], [2.8000000000000003, 0.33498815015590466], [2.9000000000000004, 0.23924932921398198], [3.0, 0.1411200080598672], [3.1, 0.04158066243329049], [3.2, -0.058374143427580086], [3.3000000000000003, -0.15774569414324865], [3.4000000000000004, -0.25554110202683167], [3.5, -0.35078322768961984], [3.6, -0.44252044329485246], [3.7, -0.5298361409084934], [3.8000000000000003, -0.6118578909427193], [3.9000000000000004, -0.6877661591839741], [4.0, -0.7568024953079282], [4.1000000000000005, -0.8182771110644108], [4.2, -0.8715757724135882], [4.3, -0.9161659367494549], [4.4, -0.951602073889516], [4.5, -0.977530117665097], [4.6000000000000005, -0.9936910036334645], [4.7, -0.9999232575641008], [4.800000000000001, -0.9961646088358406], [4.9, -0.9824526126243325], [5.0, -0.9589242746631385], [5.1000000000000005, -0.9258146823277321], [5.2, -0.8834546557201531], [5.300000000000001, -0.8322674422239008], [5.4, -0.7727644875559871], [5.5, -0.7055403255703919], [5.6000000000000005, -0.6312666378723208], [5.7, -0.5506855425976376], [5.800000000000001, -0.4646021794137566], [5.9, -0.373876664830236], [6.0, -0.27941549819892586], [6.1000000000000005, -0.18216250427209502], [6.2, -0.0830894028174964], [6.300000000000001, 0.0168139004843506], [6.4, 0.11654920485049364], [6.5, 0.21511998808781552], [6.6000000000000005, 0.3115413635133787], [6.7, 0.4048499206165983], [6.800000000000001, 0.49411335113860894], [6.9, 0.5784397643882001], [7.0, 0.6569865987187891], [7.1000000000000005, 0.7289690401258765], [7.2, 0.7936678638491531], [7.300000000000001, 0.8504366206285648], [7.4, 0.8987080958116269], [7.5, 0.9379999767747389], [7.6000000000000005, 0.9679196720314865], [7.7, 0.9881682338770004], [7.800000000000001, 0.998543345374605], [7.9, 0.998941341839772], [8.0, 0.9893582466233818], [8.1, 0.9698898108450863], [8.200000000000001, 0.9407305566797726], [8.3, 0.9021718337562933], [8.4, 0.8545989080882804], [8.5, 0.7984871126234903], [8.6, 0.7343970978741133], [8.700000000000001, 0.662969230082182], [8.8, 0.5849171928917617], [8.9, 0.5010208564578846], [9.0, 0.4121184852417566], [9.1, 0.3190983623493521], [9.200000000000001, 0.22288991410024592], [9.3, 0.1244544235070617], [9.4, 0.024775425453357765], [9.5, -0.0751511204618093], [9.600000000000001, -0.1743267812229814], [9.700000000000001, -0.2717606264109442], [9.8, -0.3664791292519284], [10, -0.5440211108893698]]\n",
+       "              );\n",
+       "\n",
+       "              const view = new google.visualization.DataView(data);\n",
+       "\n",
+       "              const options = {\n",
+       "                title: \"\",\n",
+       "                vAxis: {\n",
+       "                  title: \"bar\",\n",
+       "                  viewWindow: {\n",
+       "                    max: 1,\n",
+       "                    min: -1,\n",
+       "                  },\n",
+       "                },\n",
+       "                hAxis: {\n",
+       "                  title: \"foo\",\n",
+       "                  viewWindow: {\n",
+       "                    max: 10,\n",
+       "                    min: 0,\n",
+       "                  }\n",
+       "                },\n",
+       "                legend: { position: \"none\" },\n",
+       "              };\n",
+       "              const chart = new google.visualization.LineChart(document.getElementById(\"LineChart-1\"));\n",
+       "              chart.draw(view, options);\n",
+       "            }\n",
+       "          </script>\n",
+       "          <div id=\"LineChart-1\" style=\"width: 900px; height: 300px;\"></div>\n"
+      ],
+      "text/plain": [
+       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"\\\"], [0.0, 0.0], [0.1, 0.09983341664682815], [0.2, 0.19866933079506122], [0.30000000000000004, 0.2955202066613396], [0.4, 0.3894183423086505], [0.5, 0.479425538604203], [0.6000000000000001, 0.5646424733950355], [0.7000000000000001, 0.6442176872376911], [0.8, 0.7173560908995228], [0.9, 0.7833269096274834], [1.0, 0.8414709848078965], [1.1, 0.8912073600614354], [1.2000000000000002, 0.9320390859672264], [1.3, 0.963558185417193], [1.4000000000000001, 0.9854497299884603], [1.5, 0.9974949866040544], [1.6, 0.9995736030415051], [1.7000000000000002, 0.9916648104524686], [1.8, 0.9738476308781951], [1.9000000000000001, 0.9463000876874145], [2.0, 0.9092974268256817], [2.1, 0.8632093666488737], [2.2, 0.8084964038195901], [2.3000000000000003, 0.74570521217672], [2.4000000000000004, 0.6754631805511506], [2.5, 0.5984721441039565], [2.6, 0.5155013718214642], [2.7, 0.4273798802338298], [2.8000000000000003, 0.33498815015590466], [2.9000000000000004, 0.23924932921398198], [3.0, 0.1411200080598672], [3.1, 0.04158066243329049], [3.2, -0.058374143427580086], [3.3000000000000003, -0.15774569414324865], [3.4000000000000004, -0.25554110202683167], [3.5, -0.35078322768961984], [3.6, -0.44252044329485246], [3.7, -0.5298361409084934], [3.8000000000000003, -0.6118578909427193], [3.9000000000000004, -0.6877661591839741], [4.0, -0.7568024953079282], [4.1000000000000005, -0.8182771110644108], [4.2, -0.8715757724135882], [4.3, -0.9161659367494549], [4.4, -0.951602073889516], [4.5, -0.977530117665097], [4.6000000000000005, -0.9936910036334645], [4.7, -0.9999232575641008], [4.800000000000001, -0.9961646088358406], [4.9, -0.9824526126243325], [5.0, -0.9589242746631385], [5.1000000000000005, -0.9258146823277321], [5.2, -0.8834546557201531], [5.300000000000001, -0.8322674422239008], [5.4, -0.7727644875559871], [5.5, -0.7055403255703919], [5.6000000000000005, -0.6312666378723208], [5.7, -0.5506855425976376], [5.800000000000001, -0.4646021794137566], [5.9, -0.373876664830236], [6.0, -0.27941549819892586], [6.1000000000000005, -0.18216250427209502], [6.2, -0.0830894028174964], [6.300000000000001, 0.0168139004843506], [6.4, 0.11654920485049364], [6.5, 0.21511998808781552], [6.6000000000000005, 0.3115413635133787], [6.7, 0.4048499206165983], [6.800000000000001, 0.49411335113860894], [6.9, 0.5784397643882001], [7.0, 0.6569865987187891], [7.1000000000000005, 0.7289690401258765], [7.2, 0.7936678638491531], [7.300000000000001, 0.8504366206285648], [7.4, 0.8987080958116269], [7.5, 0.9379999767747389], [7.6000000000000005, 0.9679196720314865], [7.7, 0.9881682338770004], [7.800000000000001, 0.998543345374605], [7.9, 0.998941341839772], [8.0, 0.9893582466233818], [8.1, 0.9698898108450863], [8.200000000000001, 0.9407305566797726], [8.3, 0.9021718337562933], [8.4, 0.8545989080882804], [8.5, 0.7984871126234903], [8.6, 0.7343970978741133], [8.700000000000001, 0.662969230082182], [8.8, 0.5849171928917617], [8.9, 0.5010208564578846], [9.0, 0.4121184852417566], [9.1, 0.3190983623493521], [9.200000000000001, 0.22288991410024592], [9.3, 0.1244544235070617], [9.4, 0.024775425453357765], [9.5, -0.0751511204618093], [9.600000000000001, -0.1743267812229814], [9.700000000000001, -0.2717606264109442], [9.8, -0.3664791292519284], [10, -0.5440211108893698]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"\\\",\\n                vAxis: {\\n                  title: \\\"bar\\\",\\n                  viewWindow: {\\n                    max: 1,\\n                    min: -1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.LineChart(document.getElementById(\\\"LineChart-1\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"LineChart-1\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "curve = charty.curve do\n",
+    "  function {|x| Math.sin(x) }\n",
+    "  range x: 0..10, y: -1..1\n",
+    "  xlabel 'foo'\n",
+    "  ylabel 'bar'\n",
+    "end\n",
+    "IRuby.display(IRuby.html(curve.render))\n",
+    "nil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "          \n",
+       "          <script type=\"text/javascript\">\n",
+       "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
+       "            google.charts.setOnLoadCallback(drawChart);\n",
+       "            function drawChart() {\n",
+       "              const data = google.visualization.arrayToDataTable(\n",
+       "                [[\"foo\", \"\", \"\", \"\"], [0, 10, 90, 50], [1, 40, 80, 60], [2, 20, 70, 20], [3, 90, 60, 30], [4, 70, 50, 10], [5, \"null\", \"null\", 90], [6, \"null\", \"null\", 0], [7, \"null\", \"null\", 100], [8, \"null\", \"null\", 50]]\n",
+       "              );\n",
+       "\n",
+       "              const view = new google.visualization.DataView(data);\n",
+       "\n",
+       "              const options = {\n",
+       "                title: \"\",\n",
+       "                vAxis: {\n",
+       "                  title: \"bar\",\n",
+       "                  viewWindow: {\n",
+       "                    max: 100,\n",
+       "                    min: 1,\n",
+       "                  },\n",
+       "                },\n",
+       "                hAxis: {\n",
+       "                  title: \"foo\",\n",
+       "                  viewWindow: {\n",
+       "                    max: 10,\n",
+       "                    min: 0,\n",
+       "                  }\n",
+       "                },\n",
+       "                legend: { position: \"none\" },\n",
+       "              };\n",
+       "              const chart = new google.visualization.LineChart(document.getElementById(\"LineChart-2\"));\n",
+       "              chart.draw(view, options);\n",
+       "            }\n",
+       "          </script>\n",
+       "          <div id=\"LineChart-2\" style=\"width: 900px; height: 300px;\"></div>\n"
+      ],
+      "text/plain": [
+       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"\\\", \\\"\\\", \\\"\\\"], [0, 10, 90, 50], [1, 40, 80, 60], [2, 20, 70, 20], [3, 90, 60, 30], [4, 70, 50, 10], [5, \\\"null\\\", \\\"null\\\", 90], [6, \\\"null\\\", \\\"null\\\", 0], [7, \\\"null\\\", \\\"null\\\", 100], [8, \\\"null\\\", \\\"null\\\", 50]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"\\\",\\n                vAxis: {\\n                  title: \\\"bar\\\",\\n                  viewWindow: {\\n                    max: 100,\\n                    min: 1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.LineChart(document.getElementById(\\\"LineChart-2\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"LineChart-2\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "curve2 = charty.curve do\n",
+    "  series [0,1,2,3,4], [10,40,20,90,70]\n",
+    "  series [0,1,2,3,4], [90,80,70,60,50]\n",
+    "  series [0,1,2,3,4,5,6,7,8], [50,60,20,30,10, 90, 0, 100, 50]\n",
+    "  range x: 0..10, y: 1..100\n",
+    "  xlabel 'foo'\n",
+    "  ylabel 'bar'\n",
+    "end\n",
+    "IRuby.display(IRuby.html(curve2.render))\n",
+    "nil"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "          \n",
        "          <script type=\"text/javascript\">\n",
        "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
        "            google.charts.setOnLoadCallback(drawChart);\n",
@@ -58,28 +174,18 @@
        "                },\n",
        "                legend: { position: \"none\" },\n",
        "              };\n",
-       "              const chart = new google.visualization.BarChart(document.getElementById(\"BarChart-1\"));\n",
+       "              const chart = new google.visualization.BarChart(document.getElementById(\"BarChart-3\"));\n",
        "              chart.draw(view, options);\n",
        "            }\n",
        "          </script>\n",
-       "          <div id=\"BarChart-1\" style=\"width: 900px; height: 300px;\"></div>\n"
+       "          <div id=\"BarChart-3\" style=\"width: 900px; height: 300px;\"></div>\n"
       ],
       "text/plain": [
-       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"\\\", \\\"\\\"], [\\\"0\\\", 10, 30], [\\\"1\\\", 20, 40], [\\\"2\\\", 70, 50], [\\\"4\\\", 60, \\\"null\\\"]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"this is the title\\\",\\n                vAxis: {\\n                  title: \\\"bara\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BarChart(document.getElementById(\\\"BarChart-1\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"BarChart-1\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"foo\\\", \\\"\\\", \\\"\\\"], [\\\"0\\\", 10, 30], [\\\"1\\\", 20, 40], [\\\"2\\\", 70, 50], [\\\"4\\\", 60, \\\"null\\\"]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"this is the title\\\",\\n                vAxis: {\\n                  title: \\\"bara\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"foo\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BarChart(document.getElementById(\\\"BarChart-3\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"BarChart-3\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "#<CZTop::Socket::PUB:0x7fc4430de3c0 last_endpoint=\"tcp://127.0.0.1:49318\">"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -90,18 +196,19 @@
     "  series [0, 1, 2], [30, 40, 50]\n",
     "  title 'this is the title'\n",
     "end\n",
-    "IRuby.display(IRuby.html(bar.render))"
+    "IRuby.display(IRuby.html(bar.render))\n",
+    "nil"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\n",
+       "          \n",
        "          <script type=\"text/javascript\">\n",
        "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
        "            google.charts.setOnLoadCallback(drawChart);\n",
@@ -130,28 +237,18 @@
        "                },\n",
        "                legend: { position: \"none\" },\n",
        "              };\n",
-       "              const chart = new google.visualization.ScatterChart(document.getElementById(\"ScatterChart-2\"));\n",
+       "              const chart = new google.visualization.ScatterChart(document.getElementById(\"ScatterChart-4\"));\n",
        "              chart.draw(view, options);\n",
        "            }\n",
        "          </script>\n",
-       "          <div id=\"ScatterChart-2\" style=\"width: 900px; height: 300px;\"></div>\n"
+       "          <div id=\"ScatterChart-4\" style=\"width: 900px; height: 300px;\"></div>\n"
       ],
       "text/plain": [
-       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"\\\", \\\"sample1\\\", \\\"sample2\\\", \\\"\\\"], [\\\"0\\\", 0.0, 0.0, 0], [\\\"1\\\", 0.1, 0.2, -0.1], [\\\"2\\\", 0.2, 0.4, -0.5], [\\\"3\\\", 0.30000000000000004, 0.6000000000000001, -0.5], [\\\"4\\\", 0.4, 0.8, 0.1], [\\\"5\\\", 0.5, 1.0, \\\"null\\\"], [\\\"6\\\", 0.6000000000000001, \\\"null\\\", \\\"null\\\"], [\\\"7\\\", 0.7000000000000001, \\\"null\\\", \\\"null\\\"], [\\\"8\\\", 0.8, \\\"null\\\", \\\"null\\\"], [\\\"9\\\", 0.9, \\\"null\\\", \\\"null\\\"], [\\\"10\\\", 1.0, \\\"null\\\", \\\"null\\\"]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"scatter sample\\\",\\n                vAxis: {\\n                  title: \\\"y label\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.ScatterChart(document.getElementById(\\\"ScatterChart-2\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"ScatterChart-2\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"\\\", \\\"sample1\\\", \\\"sample2\\\", \\\"\\\"], [\\\"0\\\", 0.0, 0.0, 0], [\\\"1\\\", 0.1, 0.2, -0.1], [\\\"2\\\", 0.2, 0.4, -0.5], [\\\"3\\\", 0.30000000000000004, 0.6000000000000001, -0.5], [\\\"4\\\", 0.4, 0.8, 0.1], [\\\"5\\\", 0.5, 1.0, \\\"null\\\"], [\\\"6\\\", 0.6000000000000001, \\\"null\\\", \\\"null\\\"], [\\\"7\\\", 0.7000000000000001, \\\"null\\\", \\\"null\\\"], [\\\"8\\\", 0.8, \\\"null\\\", \\\"null\\\"], [\\\"9\\\", 0.9, \\\"null\\\", \\\"null\\\"], [\\\"10\\\", 1.0, \\\"null\\\", \\\"null\\\"]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"scatter sample\\\",\\n                vAxis: {\\n                  title: \\\"y label\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"\\\",\\n                  viewWindow: {\\n                    max: null,\\n                    min: null,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.ScatterChart(document.getElementById(\\\"ScatterChart-4\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"ScatterChart-4\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "#<CZTop::Socket::PUB:0x7fc4430de3c0 last_endpoint=\"tcp://127.0.0.1:49318\">"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -162,18 +259,19 @@
     "  ylabel 'y label'\n",
     "  title 'scatter sample'\n",
     "end\n",
-    "IRuby.display(IRuby.html(scatter.render))"
+    "IRuby.display(IRuby.html(scatter.render))\n",
+    "nil"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\n",
+       "          \n",
        "          <script type=\"text/javascript\">\n",
        "            google.charts.load(\"current\", {packages:[\"corechart\"]});\n",
        "            google.charts.setOnLoadCallback(drawChart);\n",
@@ -202,28 +300,18 @@
        "                },\n",
        "                legend: { position: \"none\" },\n",
        "              };\n",
-       "              const chart = new google.visualization.BubbleChart(document.getElementById(\"BubbleChart-3\"));\n",
+       "              const chart = new google.visualization.BubbleChart(document.getElementById(\"BubbleChart-5\"));\n",
        "              chart.draw(view, options);\n",
        "            }\n",
        "          </script>\n",
-       "          <div id=\"BubbleChart-3\" style=\"width: 900px; height: 300px;\"></div>\n"
+       "          <div id=\"BubbleChart-5\" style=\"width: 900px; height: 300px;\"></div>\n"
       ],
       "text/plain": [
-       "\"          <script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>\\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"ID\\\", \\\"X\\\", \\\"Y\\\", \\\"GROUP\\\", \\\"SIZE\\\"], [\\\"\\\", 0, 0.0, \\\"sample1\\\", 10], [\\\"\\\", 1, 0.1, \\\"sample1\\\", 100], [\\\"\\\", 2, 0.2, \\\"sample1\\\", 1000], [\\\"\\\", 3, 0.30000000000000004, \\\"sample1\\\", 20], [\\\"\\\", 4, 0.4, \\\"sample1\\\", 200], [\\\"\\\", 5, 0.5, \\\"sample1\\\", 2000], [\\\"\\\", 6, 0.6000000000000001, \\\"sample1\\\", 5], [\\\"\\\", 7, 0.7000000000000001, \\\"sample1\\\", 50], [\\\"\\\", 8, 0.8, \\\"sample1\\\", 500], [\\\"\\\", 9, 0.9, \\\"sample1\\\", 4], [\\\"\\\", 10, 1.0, \\\"sample1\\\", 40], [\\\"\\\", 0, 0.0, \\\"sample2\\\", 1], [\\\"\\\", 1, 0.2, \\\"sample2\\\", 10], [\\\"\\\", 2, 0.4, \\\"sample2\\\", 100], [\\\"\\\", 3, 0.6000000000000001, \\\"sample2\\\", 1000], [\\\"\\\", 4, 0.8, \\\"sample2\\\", 500], [\\\"\\\", 5, 1.0, \\\"sample2\\\", 100], [\\\"\\\", 0, 0, 2, 40], [\\\"\\\", 1, -0.1, 2, 30], [\\\"\\\", 2, -0.5, 2, 200], [\\\"\\\", 3, -0.5, 2, 10], [\\\"\\\", 4, 0.1, 2, 5]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"bubble sample\\\",\\n                vAxis: {\\n                  title: \\\"y label\\\",\\n                  viewWindow: {\\n                    max: 1,\\n                    min: -1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"x label\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BubbleChart(document.getElementById(\\\"BubbleChart-3\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"BubbleChart-3\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
+       "\"          \\n          <script type=\\\"text/javascript\\\">\\n            google.charts.load(\\\"current\\\", {packages:[\\\"corechart\\\"]});\\n            google.charts.setOnLoadCallback(drawChart);\\n            function drawChart() {\\n              const data = google.visualization.arrayToDataTable(\\n                [[\\\"ID\\\", \\\"X\\\", \\\"Y\\\", \\\"GROUP\\\", \\\"SIZE\\\"], [\\\"\\\", 0, 0.0, \\\"sample1\\\", 10], [\\\"\\\", 1, 0.1, \\\"sample1\\\", 100], [\\\"\\\", 2, 0.2, \\\"sample1\\\", 1000], [\\\"\\\", 3, 0.30000000000000004, \\\"sample1\\\", 20], [\\\"\\\", 4, 0.4, \\\"sample1\\\", 200], [\\\"\\\", 5, 0.5, \\\"sample1\\\", 2000], [\\\"\\\", 6, 0.6000000000000001, \\\"sample1\\\", 5], [\\\"\\\", 7, 0.7000000000000001, \\\"sample1\\\", 50], [\\\"\\\", 8, 0.8, \\\"sample1\\\", 500], [\\\"\\\", 9, 0.9, \\\"sample1\\\", 4], [\\\"\\\", 10, 1.0, \\\"sample1\\\", 40], [\\\"\\\", 0, 0.0, \\\"sample2\\\", 1], [\\\"\\\", 1, 0.2, \\\"sample2\\\", 10], [\\\"\\\", 2, 0.4, \\\"sample2\\\", 100], [\\\"\\\", 3, 0.6000000000000001, \\\"sample2\\\", 1000], [\\\"\\\", 4, 0.8, \\\"sample2\\\", 500], [\\\"\\\", 5, 1.0, \\\"sample2\\\", 100], [\\\"\\\", 0, 0, 2, 40], [\\\"\\\", 1, -0.1, 2, 30], [\\\"\\\", 2, -0.5, 2, 200], [\\\"\\\", 3, -0.5, 2, 10], [\\\"\\\", 4, 0.1, 2, 5]]\\n              );\\n\\n              const view = new google.visualization.DataView(data);\\n\\n              const options = {\\n                title: \\\"bubble sample\\\",\\n                vAxis: {\\n                  title: \\\"y label\\\",\\n                  viewWindow: {\\n                    max: 1,\\n                    min: -1,\\n                  },\\n                },\\n                hAxis: {\\n                  title: \\\"x label\\\",\\n                  viewWindow: {\\n                    max: 10,\\n                    min: 0,\\n                  }\\n                },\\n                legend: { position: \\\"none\\\" },\\n              };\\n              const chart = new google.visualization.BubbleChart(document.getElementById(\\\"BubbleChart-5\\\"));\\n              chart.draw(view, options);\\n            }\\n          </script>\\n          <div id=\\\"BubbleChart-5\\\" style=\\\"width: 900px; height: 300px;\\\"></div>\\n\""
       ]
      },
      "metadata": {},
      "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "#<CZTop::Socket::PUB:0x7fc4430de3c0 last_endpoint=\"tcp://127.0.0.1:49318\">"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -236,20 +324,14 @@
     "  ylabel 'y label'\n",
     "  title 'bubble sample'\n",
     "end\n",
-    "IRuby.display(IRuby.html(bubble.render))"
+    "IRuby.display(IRuby.html(bubble.render))\n",
+    "nil"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Ruby 2.5.5",
+   "display_name": "Ruby 2.6.2",
    "language": "ruby",
    "name": "ruby"
   },
@@ -257,7 +339,7 @@
    "file_extension": ".rb",
    "mimetype": "application/x-ruby",
    "name": "ruby",
-   "version": "2.5.5"
+   "version": "2.6.2"
   }
  },
  "nbformat": 4,

--- a/lib/charty/backends/google_chart.rb
+++ b/lib/charty/backends/google_chart.rb
@@ -36,6 +36,8 @@ module Charty
         generate_render_js("ScatterChart")
       when :bubble
         generate_render_js("BubbleChart")
+      when :curve
+        generate_render_js("LineChart")
       else
         raise NotImplementedError
       end
@@ -100,6 +102,12 @@ module Charty
               end
             end
           end
+        when :curve
+          [headers.map(&:to_s)].tap do |data_array|
+            data_hash.each do |k, v|
+              data_array << [k, v].flatten
+            end
+          end
         else
           [headers.map(&:to_s)].tap do |data_array|
             data_hash.each do |k, v|
@@ -127,7 +135,7 @@ module Charty
 
       def generate_render_js(chart_type)
         js = <<-JS
-          #{google_chart_load_tag}
+          #{google_chart_load_tag unless self.class.chart_id > 1}
           <script type="text/javascript">
             google.charts.load("current", {packages:["corechart"]});
             google.charts.setOnLoadCallback(drawChart);

--- a/lib/charty/backends/google_chart.rb
+++ b/lib/charty/backends/google_chart.rb
@@ -3,12 +3,22 @@ module Charty
     Name = "google_chart"
     attr_reader :context
 
-    def self.chart_id=(chart_id)
-      @chart_id = chart_id
-    end
+    class << self
+      attr_writer :chart_id, :google_charts_src, :with_api_load_tag
 
-    def self.chart_id
-      @chart_id ||= 0
+      def chart_id
+        @chart_id ||= 0
+      end
+
+      def with_api_load_tag
+        return @with_api_load_tag unless @with_api_load_tag.nil?
+
+        @with_api_load_tag = true
+      end
+
+      def google_charts_src
+        @google_charts_src ||= 'https://www.gstatic.com/charts/loader.js'
+      end
     end
 
     def initilize
@@ -47,8 +57,12 @@ module Charty
 
     private
 
-      def google_chart_load_tag
-        "<script type='text/javascript' src='https://www.gstatic.com/charts/loader.js'></script>"
+      def google_charts_load_tag
+        if self.class.with_api_load_tag
+          "<script type='text/javascript' src='#{self.class.google_charts_src}'></script>"
+        else
+          nil
+        end
       end
 
       def data_column_js
@@ -166,7 +180,7 @@ module Charty
 
       def generate_render_js(chart_type)
         js = <<-JS
-          #{google_chart_load_tag unless self.class.chart_id > 1}
+          #{google_charts_load_tag unless self.class.chart_id > 1}
           <script type="text/javascript">
             google.charts.load("current", {packages:["corechart"]});
             google.charts.setOnLoadCallback(drawChart);


### PR DESCRIPTION
I've added curve and barh plot types for the google_charts backend.
The screenshots below shows the rendered charts with the new implementations. Please take a look and see if it is ok.

<img width="999" alt="スクリーンショット 2019-07-18 1 13 34" src="https://user-images.githubusercontent.com/3862661/61392238-57827000-a8f9-11e9-91c3-fab1205b13bd.png">
<img width="998" alt="スクリーンショット 2019-07-18 1 13 40" src="https://user-images.githubusercontent.com/3862661/61392267-6537f580-a8f9-11e9-8ef9-80216921567b.png">
<img width="1001" alt="スクリーンショット 2019-07-18 1 13 50" src="https://user-images.githubusercontent.com/3862661/61392277-68cb7c80-a8f9-11e9-83bc-bb18c129bd91.png">
<img width="1002" alt="スクリーンショット 2019-07-18 1 13 55" src="https://user-images.githubusercontent.com/3862661/61392280-6a954000-a8f9-11e9-922e-2570824b44ce.png">
