### PR TITLE
fix a test case: Use NArrayAdapter instead of HashAdapter

### DIFF
--- a/test/table/narray_test.rb
+++ b/test/table/narray_test.rb
@@ -4,11 +4,18 @@ require 'numo/narray'
 class TableNArrayTest < Test::Unit::TestCase
   sub_test_case("an array of vectors as records") do
     def setup
-      @data = [
+      @data = Numo::DFloat[
                 Numo::DFloat[1, 2, 3, 4],
                 Numo::DFloat[5, 6, 7, 8],
               ]
       @table = Charty::Table.new(@data)
+    end
+
+    sub_test_case("#adapter") do
+      test("use Charty::TableAdapters::NArrayAdapter") do
+        assert_equal(Charty::TableAdapters::NArrayAdapter,
+                     @table.adapter.class)
+      end
     end
 
     test("#column_names") do


### PR DESCRIPTION
`@data` was Array class before this change, thus we were using HashAdapter in this test case. It fixes to use NArrayAdapter.

Notes: I noticed it when I tried to implement NArrayAdapter that can be accessed by both string and symbol. I will send other pull-request about it.