### PR TITLE
TableAdapter can be accessed both string and symbol (ActiveRecord, NArray, NMatrix)

### DIFF
--- a/lib/charty/table_adapters/active_record_adapter.rb
+++ b/lib/charty/table_adapters/active_record_adapter.rb
@@ -25,10 +25,9 @@ module Charty
       end
 
       private def resolve_column_index(column)
-        column = column.to_s if column.instance_of?(Symbol)
         case column
-        when String
-          index = column_names.index(column)
+        when String, Symbol
+          index = column_names.index(column.to_s)
           unless index
             raise IndexError, "invalid column name: #{column.inspect}"
           end

--- a/lib/charty/table_adapters/active_record_adapter.rb
+++ b/lib/charty/table_adapters/active_record_adapter.rb
@@ -25,6 +25,7 @@ module Charty
       end
 
       private def resolve_column_index(column)
+        column = column.to_s if column.instance_of?(Symbol)
         case column
         when String
           index = column_names.index(column)

--- a/lib/charty/table_adapters/narray_adapter.rb
+++ b/lib/charty/table_adapters/narray_adapter.rb
@@ -29,6 +29,7 @@ module Charty
       end
 
       private def resolve_column_index(column)
+        column = column.to_s if column.instance_of?(Symbol)
         case column
         when String
           index = column_names.index(column)

--- a/lib/charty/table_adapters/narray_adapter.rb
+++ b/lib/charty/table_adapters/narray_adapter.rb
@@ -29,10 +29,9 @@ module Charty
       end
 
       private def resolve_column_index(column)
-        column = column.to_s if column.instance_of?(Symbol)
         case column
-        when String
-          index = column_names.index(column)
+        when String, Symbol
+          index = column_names.index(column.to_s)
           return index if index
           raise IndexError, "invalid column name: #{column}"
         when Integer

--- a/lib/charty/table_adapters/nmatrix_adapter.rb
+++ b/lib/charty/table_adapters/nmatrix_adapter.rb
@@ -29,6 +29,7 @@ module Charty
       end
 
       private def resolve_column_index(column)
+        column = column.to_s if column.instance_of?(Symbol)
         case column
         when String
           index = column_names.index(column)

--- a/lib/charty/table_adapters/nmatrix_adapter.rb
+++ b/lib/charty/table_adapters/nmatrix_adapter.rb
@@ -29,10 +29,9 @@ module Charty
       end
 
       private def resolve_column_index(column)
-        column = column.to_s if column.instance_of?(Symbol)
         case column
-        when String
-          index = column_names.index(column)
+        when String, Symbol
+          index = column_names.index(column.to_s)
           return index if index
           raise IndexError, "invalid column name: #{column}"
         when Integer

--- a/test/table/activerecord_test.rb
+++ b/test/table/activerecord_test.rb
@@ -37,20 +37,40 @@ class TableActiveRecordTest < Test::Unit::TestCase
   end
 
   sub_test_case("#[]") do
-    test("row index and column name") do
-      assert_equal("baz",
-                   @table[2, "name"])
-      assert_equal(0.4,
-                   @table[3, "rate"])
+    sub_test_case("with string column name") do
+      test("row index and column name") do
+        assert_equal("baz",
+                     @table[2, "name"])
+        assert_equal(0.4,
+                     @table[3, "rate"])
+      end
+
+      test("column name only") do
+        assert_equal([1, 2, 3, 4, 5],
+                     @table["id"])
+        assert_equal(["foo", "bar", "baz", "qux", "quux"],
+                     @table["name"])
+        assert_equal([0.1, 0.2, 0.3, 0.4, 0.5],
+                     @table["rate"])
+      end
     end
 
-    test("column name only") do
-      assert_equal([1, 2, 3, 4, 5],
-                   @table["id"])
-      assert_equal(["foo", "bar", "baz", "qux", "quux"],
-                   @table["name"])
-      assert_equal([0.1, 0.2, 0.3, 0.4, 0.5],
-                   @table["rate"])
+    sub_test_case("with symbol column name") do
+      test("row index and column name") do
+        assert_equal("baz",
+                     @table[2, :name])
+        assert_equal(0.4,
+                     @table[3, :rate])
+      end
+
+      test("column name only") do
+        assert_equal([1, 2, 3, 4, 5],
+                     @table[:id])
+        assert_equal(["foo", "bar", "baz", "qux", "quux"],
+                     @table[:name])
+        assert_equal([0.1, 0.2, 0.3, 0.4, 0.5],
+                     @table[:rate])
+      end
     end
   end
 end

--- a/test/table/narray_test.rb
+++ b/test/table/narray_test.rb
@@ -49,16 +49,32 @@ class TableNArrayTest < Test::Unit::TestCase
     end
 
     sub_test_case("#[]") do
-      test("row index and column name") do
-        assert_equal(1,
-                     @table[0, "X0"])
-        assert_equal(4,
-                     @table[3, "X0"])
+      sub_test_case("with string column name") do
+        test("row index and column name") do
+          assert_equal(1,
+                       @table[0, "X0"])
+          assert_equal(4,
+                       @table[3, "X0"])
+        end
+
+        test("column name only") do
+          assert_equal(Numo::DFloat[1, 2, 3, 4, 5],
+                       @table["X0"])
+        end
       end
 
-      test("column name only") do
-        assert_equal(Numo::DFloat[1, 2, 3, 4, 5],
-                     @table["X0"])
+      sub_test_case("with symbol column name") do
+        test("row index and column name") do
+          assert_equal(1,
+                       @table[0, :X0])
+          assert_equal(4,
+                       @table[3, :X0])
+        end
+
+        test("column name only") do
+          assert_equal(Numo::DFloat[1, 2, 3, 4, 5],
+                       @table[:X0])
+        end
       end
     end
   end
@@ -79,21 +95,43 @@ class TableNArrayTest < Test::Unit::TestCase
                    @table.column_names)
     end
 
-    sub_test_case("#[]") do
-      test("row index and column name") do
-        assert_equal(2,
-                     @table[1, "X0"])
-        assert_equal(11,
-                     @table[2, "X2"])
-      end
+    sub_test_case("with string column name") do
+      sub_test_case("#[]") do
+        test("row index and column name") do
+          assert_equal(2,
+                       @table[1, "X0"])
+          assert_equal(11,
+                       @table[2, "X2"])
+        end
 
-      test("column name only") do
-        assert_equal(Numo::DFloat[1, 2, 3, 4],
-                     @table["X0"])
-        assert_equal(Numo::DFloat[5, 6, 7, 8],
-                     @table["X1"])
-        assert_equal(Numo::DFloat[9, 10, 11, 12],
-                     @table["X2"])
+        test("column name only") do
+          assert_equal(Numo::DFloat[1, 2, 3, 4],
+                       @table["X0"])
+          assert_equal(Numo::DFloat[5, 6, 7, 8],
+                       @table["X1"])
+          assert_equal(Numo::DFloat[9, 10, 11, 12],
+                       @table["X2"])
+        end
+      end
+    end
+
+    sub_test_case("with symbol column name") do
+      sub_test_case("#[]") do
+        test("row index and column name") do
+          assert_equal(2,
+                       @table[1, :X0])
+          assert_equal(11,
+                       @table[2, :X2])
+        end
+
+        test("column name only") do
+          assert_equal(Numo::DFloat[1, 2, 3, 4],
+                       @table[:X0])
+          assert_equal(Numo::DFloat[5, 6, 7, 8],
+                       @table[:X1])
+          assert_equal(Numo::DFloat[9, 10, 11, 12],
+                       @table[:X2])
+        end
       end
     end
   end

--- a/test/table/nmatrix_test.rb
+++ b/test/table/nmatrix_test.rb
@@ -49,16 +49,32 @@ class TableNMatrixTest < Test::Unit::TestCase
     end
 
     sub_test_case("#[]") do
-      test("row index and column name") do
-        assert_equal(1,
-                     @table[0, "X0"])
-        assert_equal(4,
-                     @table[3, "X0"])
+      sub_test_case("with string column name") do
+        test("row index and column name") do
+          assert_equal(1,
+                       @table[0, "X0"])
+          assert_equal(4,
+                       @table[3, "X0"])
+        end
+
+        test("column name only") do
+          assert_equal(NMatrix[1, 2, 3, 4, 5],
+                       @table["X0"])
+        end
       end
 
-      test("column name only") do
-        assert_equal(NMatrix[1, 2, 3, 4, 5],
-                     @table["X0"])
+      sub_test_case("with symbol column name") do
+        test("row index and column name") do
+          assert_equal(1,
+                       @table[0, :X0])
+          assert_equal(4,
+                       @table[3, :X0])
+        end
+
+        test("column name only") do
+          assert_equal(NMatrix[1, 2, 3, 4, 5],
+                       @table[:X0])
+        end
       end
     end
   end
@@ -80,20 +96,40 @@ class TableNMatrixTest < Test::Unit::TestCase
     end
 
     sub_test_case("#[]") do
-      test("row index and column name") do
-        assert_equal(2,
-                     @table[1, "X0"])
-        assert_equal(11,
-                     @table[2, "X2"])
+      sub_test_case("with string column name") do
+        test("row index and column name") do
+          assert_equal(2,
+                       @table[1, "X0"])
+          assert_equal(11,
+                       @table[2, "X2"])
+        end
+
+        test("column name only") do
+          assert_equal(NMatrix[1, 2, 3, 4],
+                       @table["X0"])
+          assert_equal(NMatrix[5, 6, 7, 8],
+                       @table["X1"])
+          assert_equal(NMatrix[9, 10, 11, 12],
+                       @table["X2"])
+        end
       end
 
-      test("column name only") do
-        assert_equal(NMatrix[1, 2, 3, 4],
-                     @table["X0"])
-        assert_equal(NMatrix[5, 6, 7, 8],
-                     @table["X1"])
-        assert_equal(NMatrix[9, 10, 11, 12],
-                     @table["X2"])
+      sub_test_case("with symbol column name") do
+        test("row index and column name") do
+          assert_equal(2,
+                       @table[1, :X0])
+          assert_equal(11,
+                       @table[2, :X2])
+        end
+
+        test("column name only") do
+          assert_equal(NMatrix[1, 2, 3, 4],
+                       @table[:X0])
+          assert_equal(NMatrix[5, 6, 7, 8],
+                       @table[:X1])
+          assert_equal(NMatrix[9, 10, 11, 12],
+                       @table[:X2])
+        end
       end
     end
   end


### PR DESCRIPTION
I hope to Charty::Table can be accessed by both string and symbol. so I implemented about below adapters.

- ActiveRecordAdapter
- NArrayAdapter
- NMatrixAdapter

DatasetsAdapter is implemented like below link. so It can be already accessed by both string and symbol.

https://github.com/red-data-tools/red-datasets/blob/d26c05143ed08984013b5be0c94324bdebc62eb2/lib/datasets/table.rb#L43

At this time, I'm not sure how to implement about HashAdapter and DaruAdapter.
I think these may have the same key in different formats(String and Symbol) at the same time, so I don't think it may need to be supported.