### PR TITLE
Add require to load fileutils module

### DIFF
--- a/lib/charty/backends/gruff.rb
+++ b/lib/charty/backends/gruff.rb
@@ -1,4 +1,5 @@
 require 'gruff'
+require 'fileutils'
 
 module Charty
   class Gruff < PlotterAdapter

--- a/lib/charty/backends/pyplot.rb
+++ b/lib/charty/backends/pyplot.rb
@@ -1,4 +1,5 @@
 require 'matplotlib/pyplot'
+require 'fileutils'
 
 module Charty
   class PyPlot < PlotterAdapter

--- a/lib/charty/backends/rubyplot.rb
+++ b/lib/charty/backends/rubyplot.rb
@@ -1,4 +1,5 @@
 require 'rubyplot'
+require 'fileutils'
 
 module Charty
   class Rubyplot < PlotterAdapter


### PR DESCRIPTION
I tried sample code of usage, but got the following error message. So I added `require 'fileutils'` to solve this error.

```
>ruby charty_test.rb
Traceback (most recent call last):
        2: from charty_test.rb:13:in `<main>'
        1: from C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/charty-0.1.5.dev/lib/charty/plotter.rb:232:in `render'
C:/Ruby26-x64/lib/ruby/gems/2.6.0/gems/charty-0.1.5.dev/lib/charty/backends/pyplot.rb:37:in `render': uninitialized constant Charty::PyPlot::FileUtils (NameError)
Did you mean?  FileTest
Fatal Python error: PyEval_RestoreThread: NULL tstate
```

`charty_test.rb`
```ruby
require 'charty'
charty = Charty::Plotter.new(:pyplot)

bar = charty.bar do
  series [0,1,2,3,4], [10,40,20,90,70], label: "sample1"
  series [0,1,2,3,4], [90,80,70,60,50], label: "sample2"
  series [0,1,2,3,4,5,6,7,8], [50,60,20,30,10, 90, 0, 100, 50], label: "sample3"
  range x: 0..10, y: 1..100
  xlabel 'foo'
  ylabel 'bar'
  title 'bar plot'
end
bar.render("sample_images/bar_pyplot.png")
```
