### PR TITLE
Let plotly backend support new plotting API

### DIFF
--- a/lib/charty/backends/plotly.rb
+++ b/lib/charty/backends/plotly.rb
@@ -102,6 +102,146 @@ module Charty
           </script>
         FRAGMENT
       end
+
+      # ==== NEW PLOTTING API ====
+
+      class HTML
+        def initialize(html)
+          @html = html
+        end
+
+        def to_iruby
+          ["text/html", @html]
+        end
+      end
+
+      def begin_figure
+        @traces = []
+        @layout = {}
+      end
+
+      def bar(bar_pos, values, color: nil, width: 0.8r, align: :center, orient: :v)
+        color = Array(color).map(&:to_hex_string)
+        @traces << {
+          type: :bar,
+          x: bar_pos,
+          y: values,
+          marker: {color: color}
+        }
+        @layout[:showlegend] = false
+      end
+
+      def box_plot(plot_data, positions, color:, gray:,
+                   width: 0.8r, flier_size: 5, whisker: 1.5, notch: false)
+        color = Array(color).map(&:to_hex_string)
+        plot_data.each_with_index do |group_data, i|
+          data = if group_data.empty?
+                   {type: :box, y: [] }
+                 else
+                   {type: :box, y: group_data, marker: {color: color[i]}}
+                 end
+          @traces << data
+        end
+        @layout[:showlegend] = false
+      end
+
+      def set_xlabel(label)
+        @layout[:xaxis] ||= {}
+        @layout[:xaxis][:title] = label
+      end
+
+      def set_ylabel(label)
+        @layout[:yaxis] ||= {}
+        @layout[:yaxis][:title] = label
+      end
+
+      def set_xticks(values)
+        @layout[:xaxis] ||= {}
+        @layout[:xaxis][:tickmode] = "array"
+        @layout[:xaxis][:tickvals] = values
+      end
+
+      def set_xtick_labels(labels)
+        @layout[:xaxis] ||= {}
+        @layout[:xaxis][:tickmode] = "array"
+        @layout[:xaxis][:ticktext] = labels
+      end
+
+      def set_xlim(min, max)
+        @layout[:xaxis] ||= {}
+        @layout[:xaxis][:range] = [min, max]
+      end
+
+      def disable_xaxis_grid
+        # do nothing
+      end
+
+      def show
+        unless defined?(IRuby)
+          raise NotImplementedError,
+                "Plotly backend outside of IRuby is not supported"
+        end
+
+        IRubyOutput.prepare
+
+        html = <<~HTML
+          <div id="%{id}" style="width: 100%%; height:100%%;"></div>
+          <script type="text/javascript">
+            requirejs(["plotly"], function (Plotly) {
+              Plotly.newPlot("%{id}", %{data}, %{layout});
+            });
+          </script>
+        HTML
+
+        html %= {
+          id: SecureRandom.uuid,
+          data: JSON.dump(@traces),
+          layout: JSON.dump(@layout)
+        }
+        IRuby.display(html, mime: "text/html")
+        nil
+      end
+
+      module IRubyOutput
+        @prepared = false
+
+        def self.prepare
+          return if @prepared
+
+          html = <<~HTML
+            <script type="text/javascript">
+              %{win_config}
+              %{mathjax_config}
+              require.config({
+                paths: {
+                  plotly: "https://cdn.plot.ly/plotly-latest.min"
+                }
+              });
+            </script>
+          HTML
+
+          html %= {
+            win_config: window_plotly_config,
+            mathjax_config: mathjax_config
+          }
+
+          IRuby.display(html, mime: "text/html")
+          @prepared = true
+        end
+
+        def self.window_plotly_config
+          <<~END
+            window.PlotlyConfig = {MathJaxConfig: 'local'};
+          END
+        end
+
+
+        def self.mathjax_config
+          <<~END
+            if (window.MathJax) {MathJax.Hub.Config({SVG: {font: "STIX-Web"}});}
+          END
+        end
+      end
     end
   end
 end

--- a/lib/charty/backends/plotly.rb
+++ b/lib/charty/backends/plotly.rb
@@ -55,24 +55,22 @@ module Charty
         end
       end
 
-      private
-
-      def plotly_load_tag
+      private def plotly_load_tag
         if self.class.with_api_load_tag
           "<script type='text/javascript' src='#{self.class.plotly_src}'></script>"
         else
         end
       end
 
-      def div_id
+      private def div_id
         "charty-plotly-#{self.class.chart_id}"
       end
 
-      def div_style
+      private def div_style
         "width: 100%;height: 100%;"
       end
 
-      def render_graph(context, type, options: {})
+      private def render_graph(context, type, options: {})
         data = context.series.map do |series|
           {
             type: type,
@@ -95,7 +93,7 @@ module Charty
         render_html(data, layout)
       end
 
-      def render_html(data, layout)
+      private def render_html(data, layout)
         <<~FRAGMENT
           #{plotly_load_tag unless self.class.chart_id > 1}
           <div id="#{div_id}" style="#{div_style}"></div>

--- a/lib/charty/backends/pyplot.rb
+++ b/lib/charty/backends/pyplot.rb
@@ -161,6 +161,10 @@ module Charty
 
       # ==== NEW PLOTTING API ====
 
+      def begin_figure
+        # do nothing
+      end
+
       def bar(bar_pos, values, color: nil, width: 0.8r, align: :center, orient: :v)
         bar_pos = Array(bar_pos)
         values = Array(values)

--- a/lib/charty/plotters/abstract_plotter.rb
+++ b/lib/charty/plotters/abstract_plotter.rb
@@ -71,6 +71,11 @@ module Charty
       private def array?(value)
         TableAdapters::HashAdapter.array?(value)
       end
+
+      def to_iruby
+        result = render
+        ["text/html", result] if result
+      end
     end
   end
 end

--- a/lib/charty/plotters/bar_plotter.rb
+++ b/lib/charty/plotters/bar_plotter.rb
@@ -3,6 +3,7 @@ module Charty
     class BarPlotter < CategoricalPlotter
       def render
         backend = Backends.current
+        backend.begin_figure
         draw_bars(backend)
         annotate_axes(backend)
         backend.show

--- a/lib/charty/plotters/box_plotter.rb
+++ b/lib/charty/plotters/box_plotter.rb
@@ -3,6 +3,7 @@ module Charty
     class BoxPlotter < CategoricalPlotter
       def render
         backend = Backends.current
+        backend.begin_figure
         draw_box_plot(backend)
         annotate_axes(backend)
         backend.show


### PR DESCRIPTION
I'd like to let plotly backend support new plotting API.

The example output is available on this URL:
https://nbviewer.jupyter.org/gist/mrkn/ba3605601fa696a6eda68dd8fe589a11

This pull-request is the successor of #45.
**DO NOT MERGE THIS BEFORE MERGING #45**.

You can check the actual difference in https://github.com/red-data-tools/charty/compare/new_box_plot...new_backend_api_for_plotly

### TODO

- [ ] Wite tests