### PR TITLE
Show xtick labels in unicode_plot bar graph

### DIFF
--- a/lib/charty/backends/unicode_plot.rb
+++ b/lib/charty/backends/unicode_plot.rb
@@ -55,7 +55,7 @@ module Charty
       def show
         case @figure[:type]
         when :bar
-          plot = ::UnicodePlot.barplot(@figure[:bar_pos], @figure[:values], xlabel: @layout[:xlabel])
+          plot = ::UnicodePlot.barplot(@layout[:xtick_labels], @figure[:values], xlabel: @layout[:xlabel])
         when :box
           plot = ::UnicodePlot.boxplot(@layout[:xtick_labels], @figure[:data], xlabel: @layout[:xlabel])
         end


### PR DESCRIPTION
## Input
```rb
puts Charty.bar_plot(:x, :y, data: {x: ["a", "b"], y: [10,20]}).render
```

## Output
### before
```
     ┌                                        ┐
   0 ┤■■■■■■■■■■■■■■■■■ 10.0
   1 ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 20.0
     └                                        ┘

```

### after
```
     ┌                                        ┐
   a ┤■■■■■■■■■■■■■■■■■ 10.0
   b ┤■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■ 20.0
     └                                        ┘
```

@mrkn Is there any reason to make the label behavior inconsistent with the box graph?
