### PR TITLE
not to use `sudo` when installing gems.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ $ CONFIGURE_OPTS="--enable-shared" pyenv install 3.x.x
 ### With Matplotlib
 
 ```
-sudo gem install charty --pre
-sudo gem install matplotlib
+gem install charty --pre
+gem install matplotlib
 sudo apt install python3-pip
 sudo python3 -m pip install -U pip matplotlib
 ```


### PR DESCRIPTION
Hi developers
Readme minor change.

Of course, you can use `sudo` if necessary.
But, in general, it is recommended not to use `sudo` when installing gems.