### PR TITLE
Fix incorrect line graph in Gruff backend

### DIFF
--- a/lib/charty/backends/gruff.rb
+++ b/lib/charty/backends/gruff.rb
@@ -83,7 +83,7 @@ module Charty
           p.x_axis_label = context.xlabel if context.xlabel
           p.y_axis_label = context.ylabel if context.ylabel
           context.series.each do |data|
-            p.data(data.label, data.xs.to_a)
+            p.dataxy(data.label, data.xs.to_a, data.ys.to_a)
           end
           p
         when :scatter


### PR DESCRIPTION
I noticed after running the README sample that the line graph is not drawn correctly.

This patch will fix the line graph  in Gruff backend.

### Test code
```ruby
require 'charty'
charty = Charty::Plotter.new(:gruff)

curve2 = charty.curve do
  series [0,1,2,3,4], [10,40,20,90,70], label: "sample1"
  series [0,1,2,3,4], [90,80,70,60,50], label: "sample2"
  series [0,1,2,3,4,5,6,7,8], [50,60,20,30,10, 90, 0, 100, 50], label: "sample3"
  range x: 0..10, y: 1..100
  xlabel 'foo'
  ylabel 'bar'
end
curve2.render("curve_pyplot.png")
```

### Result
Before | After
-- | --
<img src="https://user-images.githubusercontent.com/199156/83157910-18d75c00-a13f-11ea-8721-4540b9e4ed7d.png"> | <img src="https://user-images.githubusercontent.com/199156/83157969-2a206880-a13f-11ea-9c05-368979c157e6.png">


Thanks


