### PR TITLE
Fix bar_plot log with log parameter

### DIFF
--- a/charty.gemspec
+++ b/charty.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "matplotlib", ">= 1.2.0"
   spec.add_dependency "pandas", ">= 0.3.5"
   spec.add_dependency "playwright-ruby-client"
+  spec.add_dependency "pycall", ">= 1.5.2"
 
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "rake"

--- a/lib/charty/plotters/bar_plotter.rb
+++ b/lib/charty/plotters/bar_plotter.rb
@@ -91,17 +91,21 @@ module Charty
         super
 
         if self.log
-          min_value, max_value = @estimations.minmax
           if @plot_colors
+            min_value = @estimations.map(&:min).min
+            max_value = @estimations.map(&:max).max
             unless @conf_int.empty?
-              min_value = [min_value, @conf_int[0]].min
-              max_value = [max_value, @conf_int[1]].max
+              ci_min = @conf_int.map {|cis| cis.map {|ci| ci[0] }.min }.min
+              ci_max = @conf_int.map {|cis| cis.map {|ci| ci[1] }.max }.max
+              min_value = [min_value, ci_min].min
+              max_value = [max_value, ci_max].max
             end
           else
+            min_value, max_value = @estimations.minmax
             ci_min = Util.filter_map(@conf_int) { |ci| ci[0] unless ci.empty? }
             ci_max = Util.filter_map(@conf_int) { |ci| ci[1] unless ci.empty? }
-            min_value = [min_value, ci_min.min].min unless ci_min.empty?
-            max_value = [max_value, ci_max.max].max unless ci_max.empty?
+            min_value = [min_value, *ci_min].min
+            max_value = [max_value, *ci_max].max
           end
           if min_value > 1
             min_value = 0

--- a/test/plot_methods/bar_plot_test.rb
+++ b/test/plot_methods/bar_plot_test.rb
@@ -226,6 +226,16 @@ class PlotMethodsBarPlotTest < Test::Unit::TestCase
         render_plot(backend_name, plot)
       end
     end
+
+    def test_bar_plot_log(data)
+      adapter_name, backend_name = data.values_at(:adapter, :backend)
+      setup_data(adapter_name)
+      setup_backend(backend_name)
+      plot = Charty.bar_plot(data: @data, x: :x, y: :y, color: :c, log: true)
+      assert_nothing_raised do
+        render_plot(backend_name, plot)
+      end
+    end
   end
 
   sub_test_case("with nonzero origin index") do  # [GH-93]

--- a/test/plot_methods/bar_plot_test.rb
+++ b/test/plot_methods/bar_plot_test.rb
@@ -231,6 +231,16 @@ class PlotMethodsBarPlotTest < Test::Unit::TestCase
       adapter_name, backend_name = data.values_at(:adapter, :backend)
       setup_data(adapter_name)
       setup_backend(backend_name)
+      plot = Charty.bar_plot(data: @data, x: :x, y: :y, log: true)
+      assert_nothing_raised do
+        render_plot(backend_name, plot)
+      end
+    end
+
+    def test_bar_plot_log_with_color(data)
+      adapter_name, backend_name = data.values_at(:adapter, :backend)
+      setup_data(adapter_name)
+      setup_backend(backend_name)
       plot = Charty.bar_plot(data: @data, x: :x, y: :y, color: :c, log: true)
       assert_nothing_raised do
         render_plot(backend_name, plot)


### PR DESCRIPTION
Fixes the following error.

```
Failure: test_bar_plot_log[adapter: :array, backend: :plotly](PlotMethodsBarPlotTest::rendering):
  Exception raised:
  ArgumentError(<comparison of Array with Array failed>)
  /Users/mrkn/src/github.com/red-data-tools/charty/lib/charty/plotters/bar_plotter.rb:97:in `min'
  /Users/mrkn/src/github.com/red-data-tools/charty/lib/charty/plotters/bar_plotter.rb:97:in `annotate_axes'
  /Users/mrkn/src/github.com/red-data-tools/charty/lib/charty/plotters/bar_plotter.rb:53:in `render_plot'
  /Users/mrkn/src/github.com/red-data-tools/charty/lib/charty/plotters/abstract_plotter.rb:260:in `call_render_plot'
  /Users/mrkn/src/github.com/red-data-tools/charty/lib/charty/plotters/abstract_plotter.rb:254:in `render'
  /Users/mrkn/src/github.com/red-data-tools/charty/test/helper.rb:212:in `render_plot'
  /Users/mrkn/src/github.com/red-data-tools/charty/test/plot_methods/bar_plot_test.rb:236:in `block in test_bar_plot_log'
```