### PR TITLE
pandas: don't use deprecated DataFrameGroupBy.apply(include_groups: true)

### DIFF
--- a/lib/charty/table_adapters/pandas_adapter.rb
+++ b/lib/charty/table_adapters/pandas_adapter.rb
@@ -199,7 +199,7 @@ module Charty
           res = @groupby.apply(->(data) {
             res = block.call(Charty::Table.new(data), *args)
             Pandas::Series.new(data: res)
-          })
+          }, include_groups: false)
           Charty::Table.new(res)
         end
 


### PR DESCRIPTION
It's deprecated in pandas 2.3.0:

https://pandas.pydata.org/docs/whatsnew/v2.3.0.html#deprecations

> The deprecation of setting the argument include_groups to True in
> DataFrameGroupBy.apply() has been promoted from a DeprecationWarning
> to FutureWarning; only False will be allowed (GH 7155)