### PR TITLE
ci: use verbose output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('charty.gemspec') }}
         restore-keys: ${{ runner.os }}-
 
-    - run: bundle exec rake
+    - run: bundle exec test/run.rb -v
 
     - run: bundle exec rake build
 

--- a/.github/workflows/pycall.yml
+++ b/.github/workflows/pycall.yml
@@ -63,4 +63,4 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('charty.gemspec') }}
         restore-keys: ${{ runner.os }}-
 
-    - run: bundle exec rake
+    - run: bundle exec test/run.rb -v


### PR DESCRIPTION
Because some jobs may get stuck.